### PR TITLE
Support `esm` output format alias

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -15,9 +15,19 @@
  */
 
 import { Transform } from './types';
-import { OutputOptions } from 'rollup';
+import { ModuleFormat, OutputOptions } from 'rollup';
 import { CompileOptions } from 'google-closure-compiler';
 import { sync } from 'temp-write';
+
+/**
+ * Checks if output format is ESM
+ * @param format
+ * @return boolean
+ */
+export const isESMFormat = (format?: ModuleFormat | 'esm'): boolean => {
+  // TODO: remove `| 'esm'` when rollup upgrades its typings
+  return format === 'esm' || format === 'es';
+};
 
 /**
  * Generate default Closure Compiler CompileOptions an author can override if they wish.
@@ -44,7 +54,7 @@ export const defaults = (
 
   return {
     language_out: 'NO_TRANSPILE',
-    assume_function_wrapper: options.format === 'es' ? true : false,
+    assume_function_wrapper: isESMFormat(options.format) ? true : false,
     warning_level: 'QUIET',
     externs,
   };

--- a/src/transformers/exports.ts
+++ b/src/transformers/exports.ts
@@ -17,6 +17,7 @@
 import { ModuleDeclaration, ExportNamedDeclaration, ExportDefaultDeclaration } from 'estree';
 import { TransformSourceDescription, OutputOptions } from 'rollup';
 import { NamedDeclaration, DefaultDeclaration } from './parsing-utilities';
+import { isESMFormat } from '../options';
 import {
   ExportNameToClosureMapping,
   ALL_EXPORT_TYPES,
@@ -30,13 +31,13 @@ import {
 
 const HEADER = `/**
 * @fileoverview Externs built via derived configuration from Rollup or input code.
-* This extern contains top level exported members. 
+* This extern contains top level exported members.
 * @externs
 */
 `;
 
 /**
- * This Transform will apply only if the Rollup configuration is for 'es' output.
+ * This Transform will apply only if the Rollup configuration is for 'esm' output.
  *
  * In order to preserve the export statements:
  * 1. Create extern definitions for them (to keep them their names from being mangled).
@@ -48,7 +49,7 @@ export default class ExportTransform extends Transform implements TransformInter
 
   public extern(options: OutputOptions): string {
     let content = HEADER;
-    if (options.format === 'es') {
+    if (isESMFormat(options.format)) {
       Object.keys(this.exported).forEach(key => {
         content += `window['${key}'] = ${key};\n`;
       });
@@ -123,7 +124,7 @@ export default class ExportTransform extends Transform implements TransformInter
       this.context.warn(
         'Rollup Plugin Closure Compiler, OutputOptions not known before Closure Compiler invocation.',
       );
-    } else if (this.outputOptions.format === 'es') {
+    } else if (isESMFormat(this.outputOptions.format)) {
       Object.keys(this.exported).forEach(key => {
         code += `\nwindow['${key}'] = ${key}`;
       });
@@ -147,7 +148,7 @@ export default class ExportTransform extends Transform implements TransformInter
       this.context.warn(
         'Rollup Plugin Closure Compiler, OutputOptions not known before Closure Compiler invocation.',
       );
-    } else if (this.outputOptions.format === 'es') {
+    } else if (isESMFormat(this.outputOptions.format)) {
       const exportedConstants: Array<string> = [];
 
       Object.keys(this.exported).forEach(key => {

--- a/src/transformers/strict.ts
+++ b/src/transformers/strict.ts
@@ -15,6 +15,7 @@
  */
 
 import { Transform } from '../types';
+import { isESMFormat } from '../options';
 import { TransformSourceDescription } from 'rollup';
 
 const STRICT_MODE_DECLARATION = `'use strict';`;
@@ -33,7 +34,7 @@ export default class StrictTransform extends Transform {
       this.context.warn(
         'Rollup Plugin Closure Compiler, OutputOptions not known before Closure Compiler invocation.',
       );
-    } else if (this.outputOptions.format === 'es' && code.startsWith(STRICT_MODE_DECLARATION)) {
+    } else if (isESMFormat(this.outputOptions.format) && code.startsWith(STRICT_MODE_DECLARATION)) {
       // This will only remove the top level 'use strict' directive since we cannot
       // be certain source does not contain strings with the intended content.
       code = code.slice(STRICT_MODE_DECLARATION_LENGTH, code.length);

--- a/test/esmodules/esmodules.js
+++ b/test/esmodules/esmodules.js
@@ -23,18 +23,23 @@ import { promisify } from 'util';
 
 const readFile = promisify(fs.readFile);
 
-test('esm does minify', async t => {
-  const source = await readFile(join('test/esmodules/fixtures/esm.js'), 'utf8');
-  const compilerBundle = await rollup({
-    input: 'test/esmodules/fixtures/esm.js',
-    plugins: [compiler()],
-  });
-  const compilerResults = await compilerBundle.generate({
-    format: 'es',
-    sourcemap: true,
-  });
+const createTests = format => {
+  test(`${format} - does minify`, async t => {
+    const source = await readFile(join('test/esmodules/fixtures/esm.js'), 'utf8');
+    const compilerBundle = await rollup({
+      input: 'test/esmodules/fixtures/esm.js',
+      plugins: [compiler()],
+    });
+    const compilerResults = await compilerBundle.generate({
+      format,
+      sourcemap: true,
+    });
 
-  t.truthy(compilerResults.code.length < source.length);
-});
+    t.truthy(compilerResults.code.length < source.length);
+  });
+}
+
+createTests('esm');
+createTests('es');
 
 // TODO(KB): Tests verifying exported code contains the correct exported members via acorn AST parse.

--- a/test/esmodules/import.js
+++ b/test/esmodules/import.js
@@ -23,47 +23,52 @@ import { promisify } from 'util';
 
 const readFile = promisify(fs.readFile);
 
-async function input(input) {
-  const bundle = await rollup.rollup({
-    input: `test/esmodules/fixtures/${input}.js`,
-    plugins: [compiler()],
+const createTests = format => {
+  async function input(input) {
+    const bundle = await rollup.rollup({
+      input: `test/esmodules/fixtures/${input}.js`,
+      plugins: [compiler()],
+    });
+
+    return {
+      minified: await readFile(join(`test/esmodules/fixtures/${input}.minified.js`), 'utf8'),
+      code: (await bundle.generate({
+        format,
+        sourcemap: true,
+      })).code,
+    };
+  }
+
+  test(`${format} - input with import exports the only exported function`, async t => {
+    const { minified, code } = await input('importer');
+
+    t.is(code, minified);
   });
 
-  return {
-    minified: await readFile(join(`test/esmodules/fixtures/${input}.minified.js`), 'utf8'),
-    code: (await bundle.generate({
-      format: 'es',
-      sourcemap: true,
-    })).code,
-  };
+  test(`${format} - export default named function exports the default named function`, async t => {
+    const { minified, code } = await input('export-default');
+
+    t.is(code, minified);
+  });
+
+  test(`${format} - export const values exports the const values`, async t => {
+    const { minified, code } = await input('export-const');
+
+    t.is(code, minified);
+  });
+
+  test(`${format} - export class exports the class`, async t => {
+    const { minified, code } = await input('export-class');
+
+    t.is(code, minified);
+  });
+
+  test(`${format} - export default class exports the class`, async t => {
+    const { minified, code } = await input('export-default-class');
+
+    t.is(code, minified);
+  });
 }
 
-test('input with import exports the only exported function', async t => {
-  const { minified, code } = await input('importer');
-
-  t.is(code, minified);
-});
-
-test('export default named function exports the default named function', async t => {
-  const { minified, code } = await input('export-default');
-
-  t.is(code, minified);
-});
-
-test('export const values exports the const values', async t => {
-  const { minified, code } = await input('export-const');
-
-  t.is(code, minified);
-});
-
-test('export class exports the class', async t => {
-  const { minified, code } = await input('export-class');
-
-  t.is(code, minified);
-});
-
-test('export default class exports the class', async t => {
-  const { minified, code } = await input('export-default-class');
-
-  t.is(code, minified);
-});
+createTests('esm');
+createTests('es');


### PR DESCRIPTION
`esm` is a valid output format (added recently)
