### PR TITLE
Literal computed keys

### DIFF
--- a/src/transformers/literal-computed-keys.ts
+++ b/src/transformers/literal-computed-keys.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from '../types';
+import { TransformSourceDescription } from 'rollup';
+import MagicString from 'magic-string';
+import { ObjectExpression } from 'estree';
+const walk = require('acorn/dist/walk');
+
+/**
+ * Closure Compiler will not transform computed keys with literal values back to the literal value.
+ * e.g {[0]: 'value'} => {0: 'value'}
+ *
+ * This transform does so only if a computed key is a Literal, and thus easily known to be static.
+ * @see https://astexplorer.net/#/gist/d2414b45a81db3a41ee6902bfd09947a/98905f372aa36cc6814616db3c37eed5ba51bab2
+ */
+export default class LiteralComputedKeys extends Transform {
+  /**
+   * @param code source to parse, and modify
+   * @return modified input source with computed literal keys
+   */
+  public async postCompilation(code: string): Promise<TransformSourceDescription> {
+    const source = new MagicString(code);
+    const program = this.context.parse(code, { ranges: true });
+
+    walk.simple(program, {
+      ObjectExpression(node: ObjectExpression) {
+        const properties = node.properties;
+        properties.forEach(property => {
+          if (
+            property.computed &&
+            property.key.type === 'Literal' &&
+            property.range &&
+            property.value.range
+          ) {
+            source.overwrite(
+              property.range[0],
+              property.value.range[0],
+              `${property.key.value}${property.value.type !== 'FunctionExpression' ? ':' : ''}`,
+            );
+          }
+        });
+      },
+    });
+
+    return {
+      code: source.toString(),
+      map: source.generateMap(),
+    };
+  }
+}

--- a/src/transformers/literal-computed-keys.ts
+++ b/src/transformers/literal-computed-keys.ts
@@ -25,7 +25,7 @@ const walk = require('acorn/dist/walk');
  * e.g {[0]: 'value'} => {0: 'value'}
  *
  * This transform does so only if a computed key is a Literal, and thus easily known to be static.
- * @see https://astexplorer.net/#/gist/d2414b45a81db3a41ee6902bfd09947a/98905f372aa36cc6814616db3c37eed5ba51bab2
+ * @see https://astexplorer.net/#/gist/d2414b45a81db3a41ee6902bfd09947a/d7176ac33a2733e1a4b1f65ec3ac626e24f7b60d
  */
 export default class LiteralComputedKeys extends Transform {
   /**

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -17,6 +17,7 @@
 import { OutputOptions, PluginContext, InputOptions } from 'rollup';
 import { Transform } from './types';
 import IifeTransform from './transformers/iife';
+import LiteralComputedKeys from './transformers/literal-computed-keys';
 import ExportTransform from './transformers/exports';
 import ImportTransform from './transformers/imports';
 import StrictTransform from './transformers/strict';
@@ -34,6 +35,7 @@ export const createTransforms = (
 ): Array<Transform> => {
   return [
     new IifeTransform(context, options),
+    new LiteralComputedKeys(context, options),
     new StrictTransform(context, options),
     new ExportTransform(context, options),
     new ImportTransform(context, options),

--- a/test/literal-computed-keys/fixtures/literal-computed.esm.advanced.js
+++ b/test/literal-computed-keys/fixtures/literal-computed.esm.advanced.js
@@ -1,0 +1,1 @@
+console.log({0:"value"});

--- a/test/literal-computed-keys/fixtures/literal-computed.esm.default.js
+++ b/test/literal-computed-keys/fixtures/literal-computed.esm.default.js
@@ -1,0 +1,1 @@
+console.log({0:"value"});

--- a/test/literal-computed-keys/fixtures/literal-computed.js
+++ b/test/literal-computed-keys/fixtures/literal-computed.js
@@ -1,0 +1,3 @@
+console.log({
+  [0]: 'value',
+});

--- a/test/literal-computed-keys/fixtures/mixed-keys.esm.advanced.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.esm.advanced.js
@@ -1,0 +1,1 @@
+console.log({0:"value",1:"value",2:"value2",3:"value3",4(a){console.log(a)},5(a){console.log(a)}});

--- a/test/literal-computed-keys/fixtures/mixed-keys.esm.default.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.esm.default.js
@@ -1,0 +1,1 @@
+console.log({0:"value",1:"value",2:"value2",3:"value3",4(a){console.log(a)},5(a){console.log(a)}});

--- a/test/literal-computed-keys/fixtures/mixed-keys.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.js
@@ -1,0 +1,16 @@
+function bar(value) {
+  return value;
+}
+
+console.log({
+  0: 'value',
+  [1]: 'value',
+  [bar(2)]: 'value2',
+  [0 + bar(3)]: 'value3',
+  [4](value) {
+    console.log(bar(value));
+  },
+  5(value) {
+    console.log(bar(value));
+  }
+});

--- a/test/literal-computed-keys/literal-computed.js
+++ b/test/literal-computed-keys/literal-computed.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {generator} from '../generator';
+
+generator('literal-computed-keys', 'literal-computed');

--- a/test/literal-computed-keys/mixed-keys.js
+++ b/test/literal-computed-keys/mixed-keys.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {generator} from '../generator';
+
+generator('literal-computed-keys', 'mixed-keys');


### PR DESCRIPTION
Closure Compiler will not transform computed keys with literal values back to the literal value.

Example:
`{[0]: 'value'}` => `{0: 'value'}`

This transform does so only if a computed key is a Literal, and thus easily known to be static. In the future we can also evaluate other keys to determine if they are statically known but were not successfully inlined.