### PR TITLE
Fixes to Support Export Default Syntax

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -21,6 +21,7 @@ const {
 } = require('google-closure-compiler/lib/utils.js');
 import { Transform } from './types';
 import { postCompilation } from './transforms';
+import { OutputChunk } from '../node_modules/rollup';
 
 enum Platform {
   NATIVE = 'native',
@@ -38,6 +39,7 @@ const PLATFORM_PRECEDENCE = [Platform.NATIVE, Platform.JAVA, Platform.JAVASCRIPT
  */
 export default function(
   compileOptions: CompileOptions,
+  chunk: OutputChunk,
   transforms: Array<Transform>,
 ): Promise<string> {
   return new Promise((resolve: (stdOut: string) => void, reject: (error: any) => void) => {
@@ -56,7 +58,7 @@ export default function(
       if (exitCode !== 0) {
         reject(new Error(`Google Closure Compiler exit ${exitCode}: ${stdErr}`));
       } else {
-        resolve(await postCompilation(code, transforms));
+        resolve(await postCompilation(code, chunk, transforms));
       }
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,14 +17,7 @@
 import { CompileOptions } from 'google-closure-compiler';
 import * as fs from 'fs';
 import { promisify } from 'util';
-import {
-  OutputOptions,
-  RawSourceMap,
-  Plugin,
-  OutputChunk,
-  InputOptions,
-  PluginContext,
-} from 'rollup';
+import { OutputOptions, RawSourceMap, Plugin, InputOptions, PluginContext } from 'rollup';
 import compiler from './compiler';
 import options from './options';
 import { preCompilation, createTransforms, deriveFromInputSource } from './transforms';
@@ -45,9 +38,10 @@ const transformChunk = async (
   transforms: Array<Transform>,
   requestedCompileOptions: CompileOptions = {},
   sourceCode: string,
+  chunk: any,
   outputOptions: OutputOptions,
 ): Promise<{ code: string; map: RawSourceMap } | void> => {
-  const code = await preCompilation(sourceCode, outputOptions, transforms);
+  const code = await preCompilation(sourceCode, outputOptions, chunk, transforms);
   logSource('transform', sourceCode, code);
   const [compileOptions, mapFile] = options(
     requestedCompileOptions,
@@ -56,7 +50,7 @@ const transformChunk = async (
     transforms,
   );
 
-  return compiler(compileOptions, transforms).then(
+  return compiler(compileOptions, chunk, transforms).then(
     async code => {
       return { code, map: JSON.parse(await readFile(mapFile, 'utf8')) };
     },
@@ -85,7 +79,7 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
       }
     },
     transform: async (code: string, id: string) => deriveFromInputSource(code, id, transforms),
-    transformChunk: async (code: string, outputOptions: OutputOptions, chunk: OutputChunk) =>
-      await transformChunk(transforms, requestedCompileOptions, code, outputOptions),
+    transformChunk: async (code: string, outputOptions: OutputOptions, chunk: any) =>
+      await transformChunk(transforms, requestedCompileOptions, code, chunk, outputOptions),
   };
 }

--- a/src/transformers/exports.ts
+++ b/src/transformers/exports.ts
@@ -266,6 +266,7 @@ export default class ExportTransform extends Transform implements TransformInter
                     collectedExportsToAppend.push(ancestor.expression.left.property.name);
                     break;
                   case ExportClosureMapping.DEFAULT_VALUE:
+                  case ExportClosureMapping.DEFAULT_OBJECT:
                     if (ancestor.expression.left.object.range && ancestor.expression.right.range) {
                       source.overwrite(
                         ancestor.expression.left.object.range[0],

--- a/src/transformers/exports.ts
+++ b/src/transformers/exports.ts
@@ -22,8 +22,8 @@ import {
   Node,
   ClassDeclaration,
 } from 'estree';
-import { TransformSourceDescription } from 'rollup';
-import { NamedDeclaration, DefaultDeclaration } from './parsing-utilities';
+import { TransformSourceDescription, OutputChunk } from 'rollup';
+import { NamedDeclaration, DefaultDeclaration, defaultUnamedExportName } from './parsing-utilities';
 import { isESMFormat } from '../options';
 import {
   ExportNameToClosureMapping,
@@ -85,18 +85,55 @@ export default class ExportTransform extends Transform implements TransformInter
   }
 
   /**
+   * Rollup's naming scheme for default exports can sometimes clash with reserved
+   * words.
+   *
+   * Rollup protects output by renaming the values with it's own algorithm, so we need to
+   * ensure that when it changes the name of a default export this transform is aware of its
+   * new name in the output.
+   *
+   * i.e. default class {} => window._class = class {} => default class {}.
+   * @param chunk OutputChunk from Rollup for this code.
+   * @param id Rollup id reference to the source
+   */
+  private repairExportMapping(chunk: any, id: string): void {
+    const defaultExportName = defaultUnamedExportName(id);
+    if (
+      chunk.exportNames &&
+      chunk.exportNames.default &&
+      chunk.exportNames.default.safeName &&
+      defaultExportName !== chunk.exportNames.default.safeName &&
+      this.originalExports[defaultExportName]
+    ) {
+      // If there was a detected default export, we need to ensure Rollup
+      // did not rename the export.
+      this.originalExports[chunk.exportNames.default.safeName] = this.originalExports[
+        defaultExportName
+      ];
+      delete this.originalExports[defaultExportName];
+    }
+  }
+
+  /**
    * Before Closure Compiler modifies the source, we need to ensure it has window scoped
    * references to the named exports. This prevents Closure from mangling their names.
    * @param code source to parse, and modify
+   * @param chunk OutputChunk from Rollup for this code.
    * @param id Rollup id reference to the source
    * @return modified input source with window scoped references.
    */
-  public async preCompilation(code: string, id: string): Promise<TransformSourceDescription> {
+  public async preCompilation(
+    code: string,
+    chunk: any,
+    id: string,
+  ): Promise<TransformSourceDescription> {
     if (this.outputOptions === null) {
       this.context.warn(
         'Rollup Plugin Closure Compiler, OutputOptions not known before Closure Compiler invocation.',
       );
     } else if (isESMFormat(this.outputOptions.format)) {
+      this.repairExportMapping(chunk, id);
+
       const source = new MagicString(code);
       // Window scoped references for each key are required to ensure Closure Compilre retains the code.
       Object.keys(this.originalExports).forEach(key => {
@@ -118,10 +155,15 @@ export default class ExportTransform extends Transform implements TransformInter
    * After Closure Compiler has modified the source, we need to replace the window scoped
    * references we added with the intended export statements
    * @param code source post Closure Compiler Compilation
+   * @param chunk OutputChunk from Rollup for this code.
    * @param id Rollup identifier for the source
    * @return Promise containing the repaired source
    */
-  public async postCompilation(code: string, id: string): Promise<TransformSourceDescription> {
+  public async postCompilation(
+    code: string,
+    chunk: OutputChunk,
+    id: string,
+  ): Promise<TransformSourceDescription> {
     if (this.outputOptions === null) {
       this.context.warn(
         'Rollup Plugin Closure Compiler, OutputOptions not known before Closure Compiler invocation.',
@@ -223,6 +265,15 @@ export default class ExportTransform extends Transform implements TransformInter
 
                     collectedExportsToAppend.push(ancestor.expression.left.property.name);
                     break;
+                  case ExportClosureMapping.DEFAULT_VALUE:
+                    if (ancestor.expression.left.object.range && ancestor.expression.right.range) {
+                      source.overwrite(
+                        ancestor.expression.left.object.range[0],
+                        ancestor.expression.right.range[0],
+                        'export default ',
+                      );
+                    }
+                    break;
                   default:
                     if (ancestor.range) {
                       source.remove(ancestor.range[0], ancestor.range[1]);
@@ -246,103 +297,6 @@ export default class ExportTransform extends Transform implements TransformInter
       if (collectedExportsToAppend.length > 0) {
         source.append(`export {${collectedExportsToAppend.join(',')}};`);
       }
-
-      // Object.keys(exportedConstants).forEach(exportedConstant => {
-      //   let range: [number, number] | undefined = undefined;
-      //   if ((range = exportedConstants[exportedConstant].range)) {
-      //     switch(this.exported[exportedConstant]) {
-      //       case ExportClosureMapping.NAMED_FUNCTION:
-      //       // replace(`window.${key}=function`, `export function ${key}`, code, source);
-      //         source.overwrite(range[0], range[1], `export function ${exportedConstant}`);
-      //         break;
-      //       case ExportClosureMapping.NAMED_CLASS:
-      //         break;
-      //       case ExportClosureMapping.DEFAULT_FUNCTION:
-      //         break;
-      //       case ExportClosureMapping.NAMED_DEFAULT_FUNCTION:
-      //         break;
-      //       case ExportClosureMapping.DEFAULT_CLASS:
-      //         break;
-      //       case ExportClosureMapping.NAMED_DEFAULT_CLASS:
-      //         break;
-      //       case ExportClosureMapping.NAMED_CONSTANT:
-      //         break;
-      //       default:
-      //         this.context.warn(
-      //           'Rollup Plugin Closure Compiler could not restore all exports statements.',
-      //         );
-      //         break;
-      //     }
-      //     range && source.overwrite(range[0], range[1], 'new text');
-      //   }
-      // });
-
-      // console.log('exportedConstants', exportedConstants);
-      // Object.keys(this.exported).forEach(key => {
-      //   switch (this.exported[key]) {
-      //     case ExportClosureMapping.NAMED_FUNCTION:
-      //       replace(`window.${key}=function`, `export function ${key}`, code, source);
-      //       break;
-      //     case ExportClosureMapping.NAMED_CLASS:
-      //       const namedClassMatch = new RegExp(`window.${key}=(\\w+);`).exec(code);
-      //       if (namedClassMatch && namedClassMatch.length > 0) {
-      //         // Remove the declaration on window scope, i.e. `window.Exported=a;`
-      //         replace(namedClassMatch[0], '', code, source);
-      //         // Store a new export constant to output at the end. `a as Exported`
-      //         exportedConstants.push(`${namedClassMatch[1]} as ${key}`);
-      //       }
-      //       break;
-      //     case ExportClosureMapping.DEFAULT_FUNCTION:
-      //       replace(`window.${key}=function`, `export default function`, code, source);
-      //       break;
-      //     case ExportClosureMapping.NAMED_DEFAULT_FUNCTION:
-      //       replace(`window.${key}=function`, `export default function ${key}`, code, source);
-      //       break;
-      //     case ExportClosureMapping.DEFAULT_CLASS:
-      //       const defaultClassMatch = new RegExp(`window.${key}=(\\w+);`).exec(code);
-      //       if (defaultClassMatch && defaultClassMatch.length > 0) {
-      //         // Remove the declaration on window scope, i.e. `window.ExportedTwo=a;`
-      //         // Replace it with an export statement `export default a;`
-      //         replace(`class ${defaultClassMatch[1]}`, `export default class`, code, source);
-      //         replace(defaultClassMatch[0], '', code, source);
-      //       }
-      //       break;
-      //     case ExportClosureMapping.NAMED_DEFAULT_CLASS:
-      //       const namedDefaultClassMatch = new RegExp(`window.${key}=(\\w+);`).exec(code);
-      //       if (namedDefaultClassMatch && namedDefaultClassMatch.length > 0) {
-      //         // Remove the declaration on window scope, i.e. `window.ExportedTwo=a;`
-      //         // Replace it with an export statement `export default a;`
-      //         replace(
-      //           namedDefaultClassMatch[0],
-      //           `export default ${namedDefaultClassMatch[1]};`,
-      //           code,
-      //           source,
-      //         );
-      //       }
-      //       break;
-      //     case ExportClosureMapping.NAMED_CONSTANT:
-      //       // Remove the declaration on the window scope, i.e. `window.ExportedThree=value`
-      //       // Replace it with a const declaration, i.e `const ExportedThree=value`
-      //       replace(`window.${key}=`, `const ${key}=`, code, source);
-      //       // Store a new export constant to output at the end, i.e `ExportedThree`
-      //       exportedConstants.push(key);
-      //       break;
-      //     default:
-      //       this.context.warn(
-      //         'Rollup Plugin Closure Compiler could not restore all exports statements.',
-      //       );
-      //       break;
-      //   }
-      // });
-
-      // if (exportedConstants.length > 0) {
-      //   // Remove the newline at the end since we are going to append exports.
-      //   if (code.endsWith('\n')) {
-      //     source.trimLines();
-      //   }
-      //   // Append the exports that were gathered, i.e `export {a as Exported, ExportedThree};`
-      //   source.append(`export {${exportedConstants.join(',')}};`);
-      // }
 
       return {
         code: source.toString(),

--- a/src/transformers/imports.ts
+++ b/src/transformers/imports.ts
@@ -59,10 +59,15 @@ export default class ImportTransform extends Transform {
    * Before Closure Compiler modifies the source, we need to ensure external imports have been removed
    * since Closure will error out when it encounters them.
    * @param code source to parse, and modify
+   * @param chunk OutputChunk from Rollup for this code.
    * @param id Rollup id reference to the source
    * @return modified input source with external imports removed.
    */
-  public async preCompilation(code: string, id: string): Promise<TransformSourceDescription> {
+  public async preCompilation(
+    code: string,
+    chunk: any,
+    id: string,
+  ): Promise<TransformSourceDescription> {
     const source = new MagicString(code);
     const program = this.context.parse(code, { ranges: true });
     const importNodes = program.body.filter(node => ALL_IMPORT_DECLARATIONS.includes(node.type));
@@ -91,10 +96,15 @@ export default class ImportTransform extends Transform {
   /**
    * After Closure Compiler has modified the source, we need to re-add the external imports
    * @param code source post Closure Compiler Compilation
+   * @param chunk OutputChunk from Rollup for this code.
    * @param id Rollup identifier for the source
    * @return Promise containing the repaired source
    */
-  public async postCompilation(code: string, id: string): Promise<TransformSourceDescription> {
+  public async postCompilation(
+    code: string,
+    chunk: any,
+    id: string,
+  ): Promise<TransformSourceDescription> {
     const source = new MagicString(code);
     Object.values(this.importedExternalsSyntax).forEach(importedExternalSyntax =>
       source.prepend(importedExternalSyntax),

--- a/src/transformers/parsing-utilities.ts
+++ b/src/transformers/parsing-utilities.ts
@@ -121,6 +121,7 @@ export function DefaultDeclaration(
   declaration: ExportDefaultDeclaration,
 ): ExportNameToClosureMapping | null {
   if (declaration.declaration) {
+    const defaultExportName = defaultUnamedExportName(id);
     switch (declaration.declaration.type) {
       case 'FunctionDeclaration':
         const functionName = functionDeclarationName(context, id, declaration);
@@ -129,11 +130,20 @@ export function DefaultDeclaration(
             [functionName]: ExportClosureMapping.NAMED_DEFAULT_FUNCTION,
           };
         } else {
-          const functionName = defaultUnamedExportName(id);
           return {
-            [functionName]: ExportClosureMapping.DEFAULT_FUNCTION,
+            [defaultExportName]: ExportClosureMapping.DEFAULT_FUNCTION,
           };
         }
+      case 'ClassDeclaration':
+        const className = classDeclarationName(context, id, declaration);
+        if (className !== null) {
+          return {
+            [className]: ExportClosureMapping.NAMED_DEFAULT_CLASS,
+          };
+        }
+        return {
+          [defaultExportName]: ExportClosureMapping.DEFAULT_CLASS,
+        };
       case 'Identifier':
         if (declaration.declaration.name) {
           return {
@@ -141,27 +151,17 @@ export function DefaultDeclaration(
           };
         }
         break;
-      case 'ClassDeclaration':
-        const className = classDeclarationName(context, id, declaration);
-        if (className !== null) {
-          return {
-            [className]: ExportClosureMapping.NAMED_DEFAULT_CLASS,
-          };
-        } else {
-          const className = defaultUnamedExportName(id);
-          return {
-            [className]: ExportClosureMapping.DEFAULT_CLASS,
-          };
-        }
       case 'Literal':
-        const literalNameValue = defaultUnamedExportName(id);
         return {
-          [literalNameValue]: ExportClosureMapping.DEFAULT_VALUE,
+          [defaultExportName]: ExportClosureMapping.DEFAULT_VALUE,
+        };
+      case 'ObjectExpression':
+        return {
+          [defaultExportName]: ExportClosureMapping.DEFAULT_OBJECT,
         };
       case 'ArrayExpression':
-        const arrayName = defaultUnamedExportName(id);
         return {
-          [arrayName]: ExportClosureMapping.DEFAULT_VALUE,
+          [defaultExportName]: ExportClosureMapping.DEFAULT_VALUE,
         };
     }
   }

--- a/src/transformers/parsing-utilities.ts
+++ b/src/transformers/parsing-utilities.ts
@@ -103,8 +103,17 @@ export function NamedDeclaration(
     return {
       [className]: ExportClosureMapping.NAMED_CLASS,
     };
+  } else if (declaration.declaration && declaration.declaration.type === 'VariableDeclaration') {
+    const variableDeclarations = declaration.declaration.declarations;
+    const exportMap: ExportNameToClosureMapping = {};
+
+    variableDeclarations.forEach(variableDeclarator => {
+      if (variableDeclarator.id.type === 'Identifier') {
+        exportMap[variableDeclarator.id.name] = ExportClosureMapping.NAMED_CONSTANT;
+      }
+    });
+    return exportMap;
   } else if (declaration.specifiers) {
-    // console.log(declaration.specifiers);
     const exportMap: ExportNameToClosureMapping = {};
     declaration.specifiers.forEach(exportSpecifier => {
       exportMap[exportSpecifierName(exportSpecifier)] = ExportClosureMapping.NAMED_CONSTANT;

--- a/src/transformers/strict.ts
+++ b/src/transformers/strict.ts
@@ -27,10 +27,9 @@ export default class StrictTransform extends Transform {
    * When outputting an es module, runtimes automatically apply strict mode conventions.
    * This means we can safely strip the 'use strict'; declaration from the top of the file.
    * @param code source following closure compiler minification
-   * @param id Rollup Resource id
    * @return code after removing the strict mode declaration (when safe to do so)
    */
-  public async postCompilation(code: string, id: string): Promise<TransformSourceDescription> {
+  public async postCompilation(code: string): Promise<TransformSourceDescription> {
     if (this.outputOptions === null) {
       this.context.warn(
         'Rollup Plugin Closure Compiler, OutputOptions not known before Closure Compiler invocation.',

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -52,18 +52,21 @@ export const createTransforms = (
 export async function preCompilation(
   code: string,
   outputOptions: OutputOptions,
+  chunk: any,
   transforms: Array<Transform>,
 ): Promise<string> {
   // Each transform has a 'preCompilation' step that must complete before passing
   // the resulting code to Closure Compiler.
+  logSource('before preCompilation handlers', code);
   for (const transform of transforms) {
     transform.outputOptions = outputOptions;
-    const result = await transform.preCompilation(code, 'none');
+    const result = await transform.preCompilation(code, chunk, chunk.id);
     if (result && result.code) {
       code = result.code;
     }
   }
 
+  logSource('after preCompilation handlers', code);
   return code;
 }
 
@@ -73,12 +76,16 @@ export async function preCompilation(
  * @param transforms Transforms to execute.
  * @return source code following `postCompilation`
  */
-export async function postCompilation(code: string, transforms: Array<Transform>): Promise<string> {
+export async function postCompilation(
+  code: string,
+  chunk: any,
+  transforms: Array<Transform>,
+): Promise<string> {
   // Following successful Closure Compiler compilation, each transform needs an opportunity
   // to clean up work is performed in preCompilation via postCompilation.
   logSource('before postCompilation handlers', code);
   for (const transform of transforms) {
-    const result = await transform.postCompilation(code, 'none');
+    const result = await transform.postCompilation(code, chunk, chunk.id);
     if (result && result.code) {
       code = result.code;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,12 +50,17 @@ export enum ExportClosureMapping {
   DEFAULT_CLASS = 5,
   NAMED_CONSTANT = 6,
   DEFAULT = 7,
+  DEFAULT_VALUE = 8,
 }
 export interface ExportNameToClosureMapping {
   [key: string]: ExportClosureMapping;
 }
 
-export type TransformMethod = (code: string, id: string) => Promise<TransformSourceDescription>;
+export type TransformMethod = (
+  code: string,
+  chunk: any,
+  id: string,
+) => Promise<TransformSourceDescription>;
 export interface TransformInterface {
   extern: (options: OutputOptions) => string;
   deriveFromInputSource: (code: string, id: string) => Promise<void>;
@@ -80,12 +85,20 @@ export class Transform implements TransformInterface {
     return void 0;
   }
 
-  public async preCompilation(code: string, id: string): Promise<TransformSourceDescription> {
+  public async preCompilation(
+    code: string,
+    chunk: any,
+    id: string,
+  ): Promise<TransformSourceDescription> {
     return {
       code,
     };
   }
-  public async postCompilation(code: string, id: string): Promise<TransformSourceDescription> {
+  public async postCompilation(
+    code: string,
+    chunk: any,
+    id: string,
+  ): Promise<TransformSourceDescription> {
     return {
       code,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export enum ExportClosureMapping {
   NAMED_CONSTANT = 6,
   DEFAULT = 7,
   DEFAULT_VALUE = 8,
+  DEFAULT_OBJECT = 9,
 }
 export interface ExportNameToClosureMapping {
   [key: string]: ExportClosureMapping;

--- a/test/export-default/array.js
+++ b/test/export-default/array.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-default', 'array');
+generator('export-default', 'array');

--- a/test/export-default/class.js
+++ b/test/export-default/class.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-default', 'class');
+generator('export-default', 'class');

--- a/test/export-default/fixtures/array.esm.advanced.js
+++ b/test/export-default/fixtures/array.esm.advanced.js
@@ -1,0 +1,1 @@
+export default [];

--- a/test/export-default/fixtures/array.esm.default.js
+++ b/test/export-default/fixtures/array.esm.default.js
@@ -1,0 +1,1 @@
+export default [];

--- a/test/export-default/fixtures/class.esm.advanced.js
+++ b/test/export-default/fixtures/class.esm.advanced.js
@@ -1,0 +1,1 @@
+export default class{constructor(b){this.name_=b}console(){console.log(this.name_)}}

--- a/test/export-default/fixtures/class.esm.default.js
+++ b/test/export-default/fixtures/class.esm.default.js
@@ -1,0 +1,1 @@
+export default class{constructor(b){this.name_=b}console(){console.log(this.name_)}}

--- a/test/export-default/fixtures/function.esm.advanced.js
+++ b/test/export-default/fixtures/function.esm.advanced.js
@@ -1,0 +1,1 @@
+export default function(a){console.log(a);console.log(1)};

--- a/test/export-default/fixtures/function.esm.default.js
+++ b/test/export-default/fixtures/function.esm.default.js
@@ -1,0 +1,1 @@
+export default function(a){console.log(a);console.log(1)};

--- a/test/export-default/fixtures/number.esm.advanced.js
+++ b/test/export-default/fixtures/number.esm.advanced.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/export-default/fixtures/number.esm.default.js
+++ b/test/export-default/fixtures/number.esm.default.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/export-default/fixtures/object.esm.advanced.js
+++ b/test/export-default/fixtures/object.esm.advanced.js
@@ -1,0 +1,1 @@
+export default {key:"value"};

--- a/test/export-default/fixtures/object.esm.default.js
+++ b/test/export-default/fixtures/object.esm.default.js
@@ -1,0 +1,1 @@
+export default {key:"value"};

--- a/test/export-default/function.js
+++ b/test/export-default/function.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-default', 'function');
+generator('export-default', 'function');

--- a/test/export-default/number.js
+++ b/test/export-default/number.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-default', 'number');
+generator('export-default', 'number');

--- a/test/export-default/object.js
+++ b/test/export-default/object.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-default', 'object');
+generator('export-default', 'object');

--- a/test/export-variables/const-function.js
+++ b/test/export-variables/const-function.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'const-function');
+generator('export-variables', 'const-function');

--- a/test/export-variables/const-number.js
+++ b/test/export-variables/const-number.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'const-number');
+generator('export-variables', 'const-number');

--- a/test/export-variables/fixtures/const-function.esm.advanced.js
+++ b/test/export-variables/fixtures/const-function.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=function(a){console.log(a)};export {foo};

--- a/test/export-variables/fixtures/const-function.esm.default.js
+++ b/test/export-variables/fixtures/const-function.esm.default.js
@@ -1,0 +1,1 @@
+var foo=function(a){console.log(a)};export {foo};

--- a/test/export-variables/fixtures/const-number.esm.advanced.js
+++ b/test/export-variables/fixtures/const-number.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/const-number.esm.default.js
+++ b/test/export-variables/fixtures/const-number.esm.default.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/let-function.esm.advanced.js
+++ b/test/export-variables/fixtures/let-function.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=function(a){console.log(a)};export {foo};

--- a/test/export-variables/fixtures/let-function.esm.default.js
+++ b/test/export-variables/fixtures/let-function.esm.default.js
@@ -1,0 +1,1 @@
+var foo=function(a){console.log(a)};export {foo};

--- a/test/export-variables/fixtures/let-identifier.esm.advanced.js
+++ b/test/export-variables/fixtures/let-identifier.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/let-identifier.esm.default.js
+++ b/test/export-variables/fixtures/let-identifier.esm.default.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/let-number.esm.advanced.js
+++ b/test/export-variables/fixtures/let-number.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/let-number.esm.default.js
+++ b/test/export-variables/fixtures/let-number.esm.default.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/var-function.esm.advanced.js
+++ b/test/export-variables/fixtures/var-function.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=function(a){console.log(a)};export {foo};

--- a/test/export-variables/fixtures/var-function.esm.default.js
+++ b/test/export-variables/fixtures/var-function.esm.default.js
@@ -1,0 +1,1 @@
+var foo=function(a){console.log(a)};export {foo};

--- a/test/export-variables/fixtures/var-identifier.esm.advanced.js
+++ b/test/export-variables/fixtures/var-identifier.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/var-identifier.esm.default.js
+++ b/test/export-variables/fixtures/var-identifier.esm.default.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/var-number.esm.advanced.js
+++ b/test/export-variables/fixtures/var-number.esm.advanced.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/fixtures/var-number.esm.default.js
+++ b/test/export-variables/fixtures/var-number.esm.default.js
@@ -1,0 +1,1 @@
+var foo=1;export {foo};

--- a/test/export-variables/let-function.js
+++ b/test/export-variables/let-function.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'let-function');
+generator('export-variables', 'let-function');

--- a/test/export-variables/let-identifier.js
+++ b/test/export-variables/let-identifier.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'let-identifier');
+generator('export-variables', 'let-identifier');

--- a/test/export-variables/let-number.js
+++ b/test/export-variables/let-number.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'let-number');
+generator('export-variables', 'let-number');

--- a/test/export-variables/var-function.js
+++ b/test/export-variables/var-function.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'var-function');
+generator('export-variables', 'var-function');

--- a/test/export-variables/var-identifier.js
+++ b/test/export-variables/var-identifier.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'var-identifier');
+generator('export-variables', 'var-identifier');

--- a/test/export-variables/var-number.js
+++ b/test/export-variables/var-number.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-import {failureGenerator} from '../generator';
+import {generator} from '../generator';
 
-failureGenerator('export-variables', 'var-number');
+generator('export-variables', 'var-number');


### PR DESCRIPTION
We now support export default syntax for all our tests.

Note: A special case for renaming is included in this PR. Rollup by default uses the filename as the name of a default export, except when the filename is a reserved word. We are not replicating this reserved word logic, instead this recognizes when Rollup has changed the name and fixes our table of exports.