### PR TITLE
Support export * as statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/rollup-plugin-closure-compiler",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,9 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
         transformsDefined = true;
       }
     },
-    transform: async (code: string, id: string) => deriveFromInputSource(code, id, transforms),
-    transformChunk: async (code: string, outputOptions: OutputOptions, chunk: any) =>
-      await transformChunk(transforms, requestedCompileOptions, code, chunk, outputOptions),
+    transformChunk: async (code: string, outputOptions: OutputOptions, chunk: any) => {
+      await deriveFromInputSource(code, chunk.id, transforms);
+      return await transformChunk(transforms, requestedCompileOptions, code, chunk, outputOptions);
+    },
   };
 }

--- a/src/transformers/exports.ts
+++ b/src/transformers/exports.ts
@@ -52,34 +52,34 @@ export default class ExportTransform extends Transform implements TransformInter
    * @param id Rollup id reference to the source
    */
   public async deriveFromInputSource(code: string, id: string): Promise<void> {
-    if (this.isEntryPoint(id)) {
-      const context = this.context;
-      let originalExports: ExportNameToClosureMapping = {};
-      const program = context.parse(code, { ranges: true });
+    const context = this.context;
+    let originalExports: ExportNameToClosureMapping = {};
+    const program = context.parse(code, { ranges: true });
 
-      walk.simple(program, {
-        ExportNamedDeclaration(node: ExportNamedDeclaration) {
-          const namedDeclarationValues = NamedDeclaration(context, id, node);
-          if (namedDeclarationValues !== null) {
-            originalExports = { ...originalExports, ...namedDeclarationValues };
-          }
-        },
-        ExportDefaultDeclaration(node: ExportDefaultDeclaration) {
-          const defaultDeclarationValue = DefaultDeclaration(context, id, node);
-          if (defaultDeclarationValue !== null) {
-            originalExports = { ...originalExports, ...defaultDeclarationValue };
-          }
-        },
-        ExportAllDeclaration(node: ExportAllDeclaration) {
-          // TODO(KB): This case `export * from "./import"` is not currently supported.
-          context.error(
-            new Error(`Rollup Plugin Closure Compiler does not support export all syntax.`),
-          );
-        },
-      });
+    walk.simple(program, {
+      ExportNamedDeclaration(node: ExportNamedDeclaration) {
+        const namedDeclarationValues = NamedDeclaration(context, id, node);
+        if (namedDeclarationValues !== null) {
+          originalExports = { ...originalExports, ...namedDeclarationValues };
+        }
+      },
+      ExportDefaultDeclaration(node: ExportDefaultDeclaration) {
+        const defaultDeclarationValue = DefaultDeclaration(context, id, node);
+        if (defaultDeclarationValue !== null) {
+          originalExports = { ...originalExports, ...defaultDeclarationValue };
+        }
+      },
+      ExportAllDeclaration(node: ExportAllDeclaration) {
+        // TODO(KB): This case `export * from "./import"` is not currently supported.
+        context.error(
+          new Error(
+            `Rollup Plugin Closure Compiler does not support export all syntax for externals.`,
+          ),
+        );
+      },
+    });
 
-      this.originalExports = originalExports;
-    }
+    this.originalExports = originalExports;
 
     return void 0;
   }

--- a/test/export-all/all.js
+++ b/test/export-all/all.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {generator} from '../generator';
+
+generator('export-all', 'all');

--- a/test/export-all/fixtures/all.esm.advanced.js
+++ b/test/export-all/fixtures/all.esm.advanced.js
@@ -1,0 +1,1 @@
+var export1=1;var export2=function(){return 2};export{export1,export2};

--- a/test/export-all/fixtures/all.esm.default.js
+++ b/test/export-all/fixtures/all.esm.default.js
@@ -1,0 +1,1 @@
+var export1=1;var export2=function(){return 2};export{export1,export2};

--- a/test/export-all/fixtures/all.js
+++ b/test/export-all/fixtures/all.js
@@ -1,0 +1,1 @@
+export * from './dep.js';

--- a/test/export-all/fixtures/dep.js
+++ b/test/export-all/fixtures/dep.js
@@ -1,0 +1,4 @@
+export const export1 = 1;
+export function export2() {
+  return 2;
+}

--- a/test/export-default/fixtures/class.esm.advanced.js
+++ b/test/export-default/fixtures/class.esm.advanced.js
@@ -1,1 +1,1 @@
-export default class{constructor(b){this.a=b}console(){console.log(this.a)}}
+class a{constructor(b){this.a=b}console(){console.log(this.a)}}export default a;

--- a/test/export-default/fixtures/class.esm.default.js
+++ b/test/export-default/fixtures/class.esm.default.js
@@ -1,1 +1,1 @@
-export default class{constructor(b){this.name_=b}console(){console.log(this.name_)}}
+class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}export default a;

--- a/test/export-default/fixtures/named-class.esm.advanced.js
+++ b/test/export-default/fixtures/named-class.esm.advanced.js
@@ -1,1 +1,1 @@
-export default class{constructor(b){this.a=b}console(){console.log(this.a)}}
+class a{constructor(b){this.a=b}console(){console.log(this.a)}}export default a;

--- a/test/export-default/fixtures/named-class.esm.default.js
+++ b/test/export-default/fixtures/named-class.esm.default.js
@@ -1,1 +1,1 @@
-export default class{constructor(b){this.name_=b}console(){console.log(this.name_)}}
+class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}export default a;

--- a/test/export-variables/fixtures/class.esm.advanced.js
+++ b/test/export-variables/fixtures/class.esm.advanced.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.a=b}console(){console.log(this.a)}}export{a as Exported};
+class a{constructor(b){this.a=b}console(){console.log(this.a)}}var Exported=a;export{Exported};

--- a/test/export-variables/fixtures/class.esm.default.js
+++ b/test/export-variables/fixtures/class.esm.default.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}export{a as Exported};
+class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}var Exported=a;export{Exported};

--- a/test/export-variables/fixtures/function.esm.advanced.js
+++ b/test/export-variables/fixtures/function.esm.advanced.js
@@ -1,1 +1,1 @@
-export function foo(a){console.log(a)};
+var foo=function(a){console.log(a)};export{foo};

--- a/test/export-variables/fixtures/function.esm.default.js
+++ b/test/export-variables/fixtures/function.esm.default.js
@@ -1,1 +1,1 @@
-export function foo(a){console.log(a)};
+var foo=function(a){console.log(a)};export{foo};

--- a/test/import/fixtures/flattened.esm.advanced.js
+++ b/test/import/fixtures/flattened.esm.advanced.js
@@ -1,1 +1,1 @@
-export function exported(a){console.log(a);console.log(1)};
+var exported=function(a){console.log(a);console.log(1)};export{exported};

--- a/test/import/fixtures/flattened.esm.default.js
+++ b/test/import/fixtures/flattened.esm.default.js
@@ -1,1 +1,1 @@
-export function exported(a){console.log(a);console.log(1)};
+var exported=function(a){console.log(a);console.log(1)};export{exported};


### PR DESCRIPTION
The trick is simple. Rollup resolves `export *` statements into a list
of exports. The only problem here could be export * from externals.