### PR TITLE
Add peer dependency on minimum version of rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "postbuild": "rollup --config rollup.config.js",
     "lint": "tslint -c tslint.json -p tsconfig.json"
   },
+  "peerDependencies": {
+    "rollup": ">= 0.63.5"
+  },
   "dependencies": {
     "acorn": "5.7.1",
     "google-closure-compiler": "20180716.0.1",


### PR DESCRIPTION
Since the internals of Rollup are changing frequently, lets reduce the chance an older version of Rollup attempts to leverage this plugin... but doesn't pass information in the current API contract.