### PR TITLE
Ignore empty generated extern content blobs 

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -50,7 +50,13 @@ export const defaults = (
   // mangle the name of the iife wrapper.
 
   const externs = transformers
-    ? transformers.map(transform => sync(transform.extern(options))).concat(providedExterns)
+    ? transformers
+        .map(transform => {
+          const extern = transform.extern(options);
+          return extern !== '' ? sync(extern) : false;
+        })
+        .filter(Boolean)
+        .concat(providedExterns)
     : providedExterns.length > 0
       ? providedExterns
       : '';

--- a/src/transformers/iife.ts
+++ b/src/transformers/iife.ts
@@ -32,12 +32,10 @@ const HEADER = `/**
  */
 export default class IifeTransform extends Transform {
   public extern(options: OutputOptions): string {
-    let content = HEADER;
-
     if (options.format === 'iife' && options.name) {
-      content += `function ${options.name}(){};\n`;
+      return HEADER + `function ${options.name}(){};\n`;
     }
 
-    return content;
+    return '';
   }
 }


### PR DESCRIPTION
Before this change every transformer generated a string that was naively written to the FS. These files were then passed to Closure Compiler.

Now we:
1. Only generate a file for externs returned with some content.
2. Only generate a extern in the `iifeTransform` if the content is being output as an `iife`.