### PR TITLE
transformChunk -> renderChunk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,9 +1141,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "code-excerpt": {
@@ -1863,8 +1863,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1885,14 +1884,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -1907,20 +1904,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2037,8 +2031,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2050,7 +2043,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -2065,7 +2057,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -2073,14 +2064,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -2099,7 +2088,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2180,8 +2168,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2193,7 +2180,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -2279,8 +2265,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2316,7 +2301,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -2336,7 +2320,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -2380,14 +2363,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2504,12 +2485,12 @@
       "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20180910.0.0.tgz",
       "integrity": "sha512-vGhVE5M2ZY0DZWQP+NhpNxvhBP90OqDcNpQcjbRbINmWbfgN65WBnOw3c3x+Xp5siVJj1dyvRht3qplTL5rkTA==",
       "requires": {
-        "chalk": "^1.0.0",
-        "google-closure-compiler-linux": "^20180910.0.1",
-        "google-closure-compiler-osx": "^20180910.0.1",
-        "minimist": "^1.2.0",
-        "vinyl": "^2.0.1",
-        "vinyl-sourcemaps-apply": "^0.2.0"
+        "chalk": "1.1.3",
+        "google-closure-compiler-linux": "20180910.0.1",
+        "google-closure-compiler-osx": "20180910.0.1",
+        "minimist": "1.2.0",
+        "vinyl": "2.2.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "google-closure-compiler-linux": {
@@ -3577,7 +3558,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
       "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
       "requires": {
-        "sourcemap-codec": "^1.4.1"
+        "sourcemap-codec": "1.4.1"
       }
     },
     "make-dir": {
@@ -4510,7 +4491,7 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "@types/node": "10.10.1"
       }
     },
     "run-node": {
@@ -5430,12 +5411,12 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
       "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "requires": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
+        "clone": "2.1.2",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.1.2",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
       }
     },
     "vinyl-sourcemaps-apply": {
@@ -5443,7 +5424,7 @@
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       }
     },
     "wcwidth": {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -21,7 +21,6 @@ const {
 } = require('google-closure-compiler/lib/utils.js');
 import { Transform } from './types';
 import { postCompilation } from './transforms';
-import { OutputChunk } from '../node_modules/rollup';
 
 enum Platform {
   NATIVE = 'native',
@@ -39,7 +38,6 @@ const PLATFORM_PRECEDENCE = [Platform.NATIVE, Platform.JAVA, Platform.JAVASCRIPT
  */
 export default function(
   compileOptions: CompileOptions,
-  chunk: OutputChunk,
   transforms: Array<Transform>,
 ): Promise<string> {
   return new Promise((resolve: (stdOut: string) => void, reject: (error: any) => void) => {
@@ -64,7 +62,7 @@ export default function(
       } else if (exitCode !== 0) {
         reject(new Error(`Google Closure Compiler exit ${exitCode}: ${stdErr}`));
       } else {
-        resolve(await postCompilation(code, chunk, transforms));
+        resolve(await postCompilation(code, transforms));
       }
     });
   });

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -27,3 +27,6 @@ export const logSource = (preamble: string, source: string, code?: string) => {
     }
   }
 };
+
+export const log = (preamble: string, message: string) =>
+  DEBUG_ENABLED ? console.log(preamble) && console.log(message) : null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ const readFile = promisify(fs.readFile);
  * @param outputOptions Rollup Output Options.
  * @return Closure Compiled form of the Rollup Chunk
  */
-const transformChunk = async (
+const renderChunk = async (
   transforms: Array<Transform>,
   requestedCompileOptions: CompileOptions = {},
   sourceCode: string,
@@ -86,7 +86,7 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
     },
     renderChunk: async (code: string, chunk: RenderedChunk, outputOptions: OutputOptions) => {
       await deriveFromInputSource(code, chunk, transforms);
-      return await transformChunk(transforms, requestedCompileOptions, code, outputOptions);
+      return await renderChunk(transforms, requestedCompileOptions, code, outputOptions);
     },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ import {
   PluginContext,
   InputOptions,
   InputOption,
+  RenderedChunk,
 } from 'rollup';
 
 // @see https://github.com/estree/estree/blob/master/es2015.md#imports
@@ -60,14 +61,10 @@ export interface ExportNameToClosureMapping {
   };
 }
 
-export type TransformMethod = (
-  code: string,
-  chunk: any,
-  id: string,
-) => Promise<TransformSourceDescription>;
+export type TransformMethod = (code: string) => Promise<TransformSourceDescription>;
 export interface TransformInterface {
   extern: (options: OutputOptions) => string;
-  deriveFromInputSource: (code: string, id: string) => Promise<void>;
+  deriveFromInputSource: (code: string, chunk: RenderedChunk) => Promise<void>;
   preCompilation: TransformMethod;
   postCompilation: TransformMethod;
 }
@@ -85,24 +82,16 @@ export class Transform implements TransformInterface {
     return '';
   }
 
-  public async deriveFromInputSource(code: string, id: string): Promise<void> {
+  public async deriveFromInputSource(code: string, chunk: RenderedChunk): Promise<void> {
     return void 0;
   }
 
-  public async preCompilation(
-    code: string,
-    chunk: any,
-    id: string,
-  ): Promise<TransformSourceDescription> {
+  public async preCompilation(code: string): Promise<TransformSourceDescription> {
     return {
       code,
     };
   }
-  public async postCompilation(
-    code: string,
-    chunk: any,
-    id: string,
-  ): Promise<TransformSourceDescription> {
+  public async postCompilation(code: string): Promise<TransformSourceDescription> {
     return {
       code,
     };
@@ -110,12 +99,12 @@ export class Transform implements TransformInterface {
 
   protected isEntryPoint(id: string) {
     const inputs = (input: InputOption): Array<string> => {
-      if (typeof this.inputOptions.input === 'string') {
-        return [this.inputOptions.input];
-      } else if (typeof this.inputOptions.input === 'object') {
-        return Object.values(this.inputOptions.input);
+      if (typeof input === 'string') {
+        return [input];
+      } else if (typeof input === 'object') {
+        return Object.values(input);
       } else {
-        return this.inputOptions.input;
+        return input;
       }
     };
 


### PR DESCRIPTION
`TransformChunk` is deprecated. Time to move to `RenderChunk`.

This also gives us the opportunity to remove more logic that was previously needed when our parser ran before `Rollup` had completed its mutations to the source.