### PR TITLE
Remove exports before calling closure compiler

### DIFF
--- a/src/transformers/exports.ts
+++ b/src/transformers/exports.ts
@@ -99,8 +99,12 @@ export default class ExportTransform extends Transform implements TransformInter
       );
     } else if (isESMFormat(this.outputOptions.format)) {
       const source = new MagicString(code);
-      // Window scoped references for each key are required to ensure Closure Compilre retains the code.
       Object.keys(this.originalExports).forEach(key => {
+        // Remove export statements before Closure Compiler sees the code
+        // This prevents CC from transpiling `export` statements when the language_out is set to a value
+        // where exports were not part of the language.
+        source.remove(this.originalExports[key].range[0], this.originalExports[key].range[1]);
+        // Window scoped references for each key are required to ensure Closure Compilre retains the code.
         source.append(`\nwindow['${key}'] = ${key}`);
       });
 

--- a/src/transformers/parsing-utilities.ts
+++ b/src/transformers/parsing-utilities.ts
@@ -76,6 +76,10 @@ export function NamedDeclaration(
       [functionName]: {
         alias: null,
         type: ExportClosureMapping.NAMED_FUNCTION,
+        range: [
+          declaration.range ? declaration.range[0] : 0,
+          declaration.range ? declaration.range[1] : 0,
+        ],
       },
     };
   } else if (className !== null) {
@@ -83,6 +87,10 @@ export function NamedDeclaration(
       [className]: {
         alias: null,
         type: ExportClosureMapping.NAMED_CLASS,
+        range: [
+          declaration.range ? declaration.range[0] : 0,
+          declaration.range ? declaration.range[1] : 0,
+        ],
       },
     };
   } else if (declaration.declaration && declaration.declaration.type === 'VariableDeclaration') {
@@ -94,6 +102,10 @@ export function NamedDeclaration(
         exportMap[variableDeclarator.id.name] = {
           alias: null,
           type: ExportClosureMapping.NAMED_CONSTANT,
+          range: [
+            declaration.range ? declaration.range[0] : 0,
+            declaration.range ? declaration.range[1] : 0,
+          ],
         };
       }
     });
@@ -107,6 +119,10 @@ export function NamedDeclaration(
         exportMap[exportSpecifier.local.name] = {
           alias: null,
           type: ExportClosureMapping.DEFAULT,
+          range: [
+            declaration.range ? declaration.range[0] : 0,
+            declaration.range ? declaration.range[1] : 0,
+          ],
         };
       } else {
         exportMap[exportSpecifier.local.name] = {
@@ -115,6 +131,10 @@ export function NamedDeclaration(
               ? exportSpecifier.exported.name
               : null,
           type: ExportClosureMapping.NAMED_CONSTANT,
+          range: [
+            declaration.range ? declaration.range[0] : 0,
+            declaration.range ? declaration.range[1] : 0,
+          ],
         };
       }
     });
@@ -137,6 +157,10 @@ export function DefaultDeclaration(
             [functionName]: {
               alias: null,
               type: ExportClosureMapping.NAMED_DEFAULT_FUNCTION,
+              range: [
+                declaration.range ? declaration.range[0] : 0,
+                declaration.range ? declaration.range[1] : 0,
+              ],
             },
           };
         }
@@ -148,6 +172,10 @@ export function DefaultDeclaration(
             [className]: {
               alias: null,
               type: ExportClosureMapping.NAMED_DEFAULT_CLASS,
+              range: [
+                declaration.range ? declaration.range[0] : 0,
+                declaration.range ? declaration.range[1] : 0,
+              ],
             },
           };
         }
@@ -158,6 +186,10 @@ export function DefaultDeclaration(
             [declaration.declaration.name]: {
               alias: null,
               type: ExportClosureMapping.NAMED_DEFAULT_FUNCTION,
+              range: [
+                declaration.range ? declaration.range[0] : 0,
+                declaration.range ? declaration.range[1] : 0,
+              ],
             },
           };
         }
@@ -168,6 +200,10 @@ export function DefaultDeclaration(
             [declaration.declaration.name]: {
               alias: null,
               type: ExportClosureMapping.NAMED_DEFAULT_FUNCTION,
+              range: [
+                declaration.range ? declaration.range[0] : 0,
+                declaration.range ? declaration.range[1] : 0,
+              ],
             },
           };
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface ExportNameToClosureMapping {
   [key: string]: {
     alias: string | null;
     type: ExportClosureMapping;
+    range: [number, number];
   };
 }
 

--- a/test/provided-externs/fixtures/class.esm.advanced.js
+++ b/test/provided-externs/fixtures/class.esm.advanced.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.a=b}console(){console.log(this.a)}}var Exported=a;export{Exported};
+class a{constructor(b){this.a=b}console(){console.log(this.a)}}var ExportThis=a;export{ExportThis};

--- a/test/provided-externs/fixtures/class.esm.default.js
+++ b/test/provided-externs/fixtures/class.esm.default.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}var Exported=a;export{Exported};
+class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}var ExportThis=a;export{ExportThis};

--- a/test/provided-externs/fixtures/class.js
+++ b/test/provided-externs/fixtures/class.js
@@ -1,4 +1,7 @@
-export class Exported {
+/**
+ * @implements {Exported}
+ */
+export class ExportThis {
   /** 
    * @param {!string} name 
    */


### PR DESCRIPTION
First take at resolving #56.

Having issues with npm linking locally, but this change removes all exports from source before Closure Compiler acts on the source. This prevents Closure Compiler from transpiling the export statements in some scenarios.