### PR TITLE
Fix for deleting options off the passed compile options

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -99,12 +99,13 @@ export const defaults = (
  * @param transforms
  */
 export default function(
-  compileOptions: CompileOptions,
+  incomingCompileOptions: CompileOptions,
   outputOptions: OutputOptions,
   code: string,
   transforms: Array<Transform> | null,
 ): [CompileOptions, string] {
-  const mapFile = sync('');
+  const mapFile: string = sync('');
+  const compileOptions: CompileOptions = { ...incomingCompileOptions };
   let externs: Array<string> = [];
 
   validateCompileOptions(compileOptions);

--- a/test/provided-externs/multiple-bundles.js
+++ b/test/provided-externs/multiple-bundles.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const test = require('ava');
+const path = require('path');
+const rollup = require('rollup');
+const { default: compiler } = require('../../transpile/index');
+
+const options = {
+  externs: [
+    path.resolve('test', 'provided-externs', 'fixtures', 'class.externs.js'),
+  ],
+  compilation_level: 'ADVANCED',
+};
+const optionsCopy = {...options};
+
+async function compile() {
+  const bundle = await rollup.rollup({
+    input: `test/provided-externs/fixtures/class.js`,
+    plugins: [
+      compiler(options),
+    ],
+  });
+
+  await bundle.generate({
+    format: 'es',
+    sourcemap: true,
+  });
+}
+
+test(`building does not modify passed configuration`, async t => {
+  await compile();
+
+  t.deepEqual(options, optionsCopy);
+});


### PR DESCRIPTION
Addresses the issue that re-opened #49.

We were deleting an item off `compileOptions` that we should have cloned first. 