### PR TITLE
Remove deriveFromInputSource lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/rollup-plugin-closure-compiler",
-  "version": "0.7.3",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2578,15 +2578,13 @@
         "minimist": "1.2.0",
         "vinyl": "2.2.0",
         "vinyl-sourcemaps-apply": "0.2.1"
-      },
-      "dependencies": {
-        "google-closure-compiler-linux": {
-          "version": "20181008.0.0",
-          "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20181008.0.0.tgz",
-          "integrity": "sha512-k8njGfH2uzWJiRPPvUxM7MJB28gPrf4kI2bbuiF0gJk/1arXcWCPGjLD6pzCU0UylMy52MUXLgsIpRorqf2brw==",
-          "optional": true
-        }
       }
+    },
+    "google-closure-compiler-linux": {
+      "version": "20181008.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20181008.0.0.tgz",
+      "integrity": "sha512-k8njGfH2uzWJiRPPvUxM7MJB28gPrf4kI2bbuiF0gJk/1arXcWCPGjLD6pzCU0UylMy52MUXLgsIpRorqf2brw==",
+      "optional": true
     },
     "google-closure-compiler-osx": {
       "version": "20181008.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
 } from 'rollup';
 import compiler from './compiler';
 import options from './options';
-import { preCompilation, createTransforms, deriveFromInputSource } from './transforms';
+import { preCompilation, createTransforms } from './transforms';
 import { Transform } from './types';
 
 const readFile = promisify(fs.readFile);
@@ -85,7 +85,6 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
     },
     renderChunk: async (code: string, chunk: RenderedChunk, outputOptions: OutputOptions) => {
       const transforms = createTransforms(context, inputOptions);
-      await deriveFromInputSource(code, chunk, transforms);
       return await renderChunk(transforms, requestedCompileOptions, code, outputOptions);
     },
   };

--- a/src/transforms.ts
+++ b/src/transforms.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { OutputOptions, PluginContext, InputOptions, RenderedChunk } from 'rollup';
+import { OutputOptions, PluginContext, InputOptions } from 'rollup';
 import { Transform } from './types';
 import IifeTransform from './transformers/iife';
 import LiteralComputedKeys from './transformers/literal-computed-keys';
@@ -88,20 +88,4 @@ export async function postCompilation(code: string, transforms: Array<Transform>
 
   logSource('after postCompilation handlers', code);
   return code;
-}
-
-/**
- * Run each transform's `deriveFromInputSource` phase in parallel.
- * @param code source code to derive information from, pre Closure Compiler minification.
- * @param id Rollup identifier for this input source.
- * @param transforms Transforms to execute.
- */
-export async function deriveFromInputSource(
-  code: string,
-  chunk: RenderedChunk,
-  transforms: Array<Transform>,
-): Promise<void> {
-  await Promise.all(transforms.map(transform => transform.deriveFromInputSource(code, chunk))).then(
-    _ => void 0,
-  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,6 @@ import {
   PluginContext,
   InputOptions,
   InputOption,
-  RenderedChunk,
 } from 'rollup';
 const dynamicImport = require('acorn-dynamic-import');
 
@@ -66,7 +65,6 @@ export interface ExportNameToClosureMapping {
 export type TransformMethod = (code: string) => Promise<TransformSourceDescription>;
 export interface TransformInterface {
   extern: (options: OutputOptions) => string;
-  deriveFromInputSource: (code: string, chunk: RenderedChunk) => Promise<void>;
   preCompilation: TransformMethod;
   postCompilation: TransformMethod;
 }
@@ -82,10 +80,6 @@ export class Transform implements TransformInterface {
 
   public extern(options: OutputOptions): string {
     return '';
-  }
-
-  public async deriveFromInputSource(code: string, chunk: RenderedChunk): Promise<void> {
-    return void 0;
   }
 
   public async preCompilation(code: string): Promise<TransformSourceDescription> {


### PR DESCRIPTION
As a preparation step for `0.9.0`, which will address #92, let's simplify the existing API by removing the currently unnecessary `deriveFromInputSource` lifecycle method.