### PR TITLE
Export CJS auto generate extern

### DIFF
--- a/test/export-cjs/export-cjs-extern.test.js
+++ b/test/export-cjs/export-cjs-extern.test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import test from 'ava';
+import { createTransforms } from '../../transpile/transforms';
+import { defaults } from '../../transpile/options';
+import * as fs from 'fs';
+import { promisify } from 'util';
+
+const readFile = promisify(fs.readFile);
+
+test('generate extern for cjs export pattern', async t => {
+  const externFixtureContent = await readFile('test/export-cjs/fixtures/export.extern.js', 'utf8');
+  const outputOptions = {
+    format: 'cjs',
+  };
+
+  const transforms = createTransforms({});
+  const options = defaults(outputOptions, [], transforms);
+
+  const contentMatch = options.externs.some(async externFilePath => {
+    const fileContent = await readFile(externFilePath, 'utf8');
+    return fileContent === externFixtureContent;
+  });
+
+  t.is(contentMatch, true);
+});

--- a/test/export-cjs/fixtures/export.extern.js
+++ b/test/export-cjs/fixtures/export.extern.js
@@ -1,0 +1,12 @@
+/**
+* @fileoverview Externs built via derived configuration from Rollup or input code.
+* This extern contains the export global object so Closure doesn't get confused by its presence.
+* @externs
+*/
+
+/**
+ * @typedef {{
+ *   __esModule: boolean,
+ * }}
+ */
+let exports;


### PR DESCRIPTION
When the output is a CJS file, and the author is attempting to use Advanced Optimizations... we need to provide Closure Compiler an extern for the `exports` global used by Babel and TypeScript to indicate an input was originally a ESM module.