### PR TITLE
Move to latest Node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
+dist: xenial
 sudo: required  # See http://docs.travis-ci.com/user/trusty-ci-environment/
-dist: trusty
 node_js:
   - "lts/*"
 before_install:
@@ -12,3 +12,4 @@ branches:
 cache:
   directories:
     - node_modules
+  yarn: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "The AMP HTML Authors",
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "keywords": [
     "rollup-plugin"
@@ -25,7 +25,6 @@
     "build": "rimraf dist transpile && tsc -p tsconfig.json & wait",
     "postbuild": "rollup --config rollup.config.js",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "lint:fix": "tslint -c tslint.json -p tsconfig.json --fix",
     "release": "np",
     "prepublishOnly": "npm-run-all build"
   },
@@ -60,7 +59,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "npm-run-all lint:fix",
+      "yarn lint --fix",
       "prettier --config .prettierrc --write",
       "git add"
     ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,7 @@
  */
 
 import { CompileOptions } from 'google-closure-compiler';
-import * as fs from 'fs';
-import { promisify } from 'util';
+import { promises as fsPromises } from 'fs';
 import {
   OutputOptions,
   RawSourceMap,
@@ -29,8 +28,6 @@ import compiler from './compiler';
 import options from './options';
 import { preCompilation, createTransforms } from './transforms';
 import { Transform } from './types';
-
-const readFile = promisify(fs.readFile);
 
 /**
  * Transform the tree-shaken code from Rollup with Closure Compiler (with derived configuration and transforms)
@@ -56,7 +53,7 @@ const renderChunk = async (
 
   return compiler(compileOptions, transforms).then(
     async code => {
-      return { code, map: JSON.parse(await readFile(mapFile, 'utf8')) };
+      return { code, map: JSON.parse(await fsPromises.readFile(mapFile, 'utf8')) };
     },
     (error: Error) => {
       throw error;

--- a/test/closure-config/rollup-config-externs.test.js
+++ b/test/closure-config/rollup-config-externs.test.js
@@ -17,9 +17,7 @@
 import test from 'ava';
 import compile from '../../transpile/options';
 import path from 'path';
-import fs from 'fs';
-import util from 'util';
-const readFile = util.promisify(fs.readFile);
+import {promises as fsPromises} from 'fs';
 
 const PROVIDED_EXTERN = path.resolve('test', 'closure-config', 'fixtures', 'externs.js');
 const IIFE_TRANSFORM_EXTERN_CONTENT = '/** @externs */ function wrapper(){}';
@@ -51,6 +49,6 @@ test('when rollup configuration specifies externs, extern is leveraged', async t
   // While we can use the path for the provided extern, we need to inspect the content of 
   // the other extern to ensure it is the generated extern.
   // Externs are passed as filepaths to Closure Compiler.
-  const fileContent = await readFile(compilerOptionsExterns.filter(path => path !== PROVIDED_EXTERN)[0], 'utf8');
+  const fileContent = await fsPromises.readFile(compilerOptionsExterns.filter(path => path !== PROVIDED_EXTERN)[0], 'utf8');
   t.true(fileContent === IIFE_TRANSFORM_EXTERN_CONTENT);
 });

--- a/test/export-cjs/export-cjs-extern.test.js
+++ b/test/export-cjs/export-cjs-extern.test.js
@@ -17,13 +17,10 @@
 import test from 'ava';
 import { createTransforms } from '../../transpile/transforms';
 import { defaults } from '../../transpile/options';
-import * as fs from 'fs';
-import { promisify } from 'util';
-
-const readFile = promisify(fs.readFile);
+import { promises as fsPromises } from 'fs';
 
 test('generate extern for cjs export pattern', async t => {
-  const externFixtureContent = await readFile('test/export-cjs/fixtures/export.extern.js', 'utf8');
+  const externFixtureContent = await fsPromises.readFile('test/export-cjs/fixtures/export.extern.js', 'utf8');
   const outputOptions = {
     format: 'cjs',
   };
@@ -32,7 +29,7 @@ test('generate extern for cjs export pattern', async t => {
   const options = defaults(outputOptions, [], transforms);
 
   const contentMatch = options.externs.some(async externFilePath => {
-    const fileContent = await readFile(externFilePath, 'utf8');
+    const fileContent = await fsPromises.readFile(externFilePath, 'utf8');
     return fileContent === externFixtureContent;
   });
 

--- a/test/generator.js
+++ b/test/generator.js
@@ -19,9 +19,6 @@ const { default: compiler } = require('../transpile/index');
 const rollup = require('rollup');
 const fs = require('fs');
 const path = require('path');
-const util = require('util');
-
-const readFile = util.promisify(fs.readFile);
 
 const DEFAULT_CLOSURE_OPTIONS = { default: {} };
 const ADVANCED_CLOSURE_OPTIONS = {
@@ -74,7 +71,7 @@ function generate(shouldFail, category, name, codeSplit, formats, closureFlags) 
     const output = [];
     if (bundles.output) {
       for (file in bundles.output) {
-        const minified = await readFile(
+        const minified = await fs.promises.readFile(
           path.join(
             fixtureLocation(
               category,
@@ -92,7 +89,7 @@ function generate(shouldFail, category, name, codeSplit, formats, closureFlags) 
         });
       }
     } else {
-      const minified = await readFile(
+      const minified = await fs.promises.readFile(
         path.join(
           fixtureLocation(category, path.parse(bundles.fileName).name, format, optionKey, true),
         ),

--- a/test/iife/iife-wrapped-safely.test.js
+++ b/test/iife/iife-wrapped-safely.test.js
@@ -19,11 +19,9 @@ import compiler from '../../transpile';
 import { createTransforms } from '../../transpile/transforms';
 import { defaults } from '../../transpile/options';
 import * as rollup from 'rollup';
-import * as fs from 'fs';
+import {promises as fsPromises} from 'fs';
 import { join } from 'path';
-import { promisify } from 'util';
 
-const readFile = promisify(fs.readFile);
 const formats = ['iife'];
 const closureFlags = {
   default: {},
@@ -37,7 +35,7 @@ const closureFlags = {
 };
 
 test('generate extern for iife name', async t => {
-  const externFixtureContent = await readFile('test/iife/fixtures/iife.extern.js', 'utf8');
+  const externFixtureContent = await fsPromises.readFile('test/iife/fixtures/iife.extern.js', 'utf8');
   const outputOptions = {
     format: 'iife',
     name: 'wrapper',
@@ -47,7 +45,7 @@ test('generate extern for iife name', async t => {
   const options = defaults(outputOptions, [], transforms);
 
   const contentMatch = options.externs.some(async externFilePath => {
-    const fileContent = await readFile(externFilePath, 'utf8');
+    const fileContent = await fsPromises.readFile(externFilePath, 'utf8');
     return fileContent === externFixtureContent;
   });
 
@@ -64,7 +62,7 @@ formats.forEach(format => {
     });
 
     return {
-      minified: await readFile(join(`test/${name}/fixtures/${format}.${option}.minified.js`), 'utf8'),
+      minified: await fsPromises.readFile(join(`test/${name}/fixtures/${format}.${option}.minified.js`), 'utf8'),
       code: (await bundle.generate({
         format,
         name: 'wrapper',


### PR DESCRIPTION
This means we can also shift to fsPromises instead of promisifying every fs.readFile usage in the codebase.