### PR TITLE
Terser syntax for exporting identifiers

### DIFF
--- a/src/transformers/imports.ts
+++ b/src/transformers/imports.ts
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-import { Transform, Range } from '../types';
+import {
+  Transform,
+  Range,
+  IMPORT_SPECIFIER,
+  IMPORT_NAMESPACE_SPECIFIER,
+  IMPORT_DEFAULT_SPECIFIER,
+} from '../types';
 import { literalName, importLocalNames } from './parsing-utilities';
 import { TransformSourceDescription } from 'rollup';
 import MagicString from 'magic-string';
-import { ImportDeclaration, Identifier } from 'estree';
+import { ImportDeclaration, Identifier, ImportSpecifier } from 'estree';
 import { parse, walk } from '../acorn';
 
 const DYNAMIC_IMPORT_KEYWORD = 'import';
@@ -85,7 +91,27 @@ window['${DYNAMIC_IMPORT_REPLACEMENT}'] = ${DYNAMIC_IMPORT_REPLACEMENT};`;
       async ImportDeclaration(node: ImportDeclaration) {
         const name = literalName(self.context, node.source);
         const range: Range = node.range as Range;
-        self.importedExternalsSyntax[name] = code.slice(...range);
+
+        let defaultSpecifier: string | null = null;
+        const specificSpecifiers: Array<string> = [];
+        for (const specifier of node.specifiers) {
+          switch (specifier.type) {
+            case IMPORT_SPECIFIER:
+            case IMPORT_NAMESPACE_SPECIFIER:
+              const { name: local } = (specifier as ImportSpecifier).local;
+              const { name: imported } = (specifier as ImportSpecifier).imported;
+              specificSpecifiers.push(local === imported ? local : `${imported} as ${local}`);
+              break;
+            case IMPORT_DEFAULT_SPECIFIER:
+              defaultSpecifier = specifier.local.name;
+              break;
+          }
+        }
+        self.importedExternalsSyntax[name] = `import ${
+          defaultSpecifier !== null ? `${defaultSpecifier},` : ''
+        }${
+          specificSpecifiers.length > 0 ? `{${specificSpecifiers.join(',')}}` : ''
+        } from '${name}';`;
         source.remove(...range);
 
         self.importedExternalsLocalNames = self.importedExternalsLocalNames.concat(

--- a/src/transformers/imports.ts
+++ b/src/transformers/imports.ts
@@ -108,7 +108,9 @@ window['${DYNAMIC_IMPORT_REPLACEMENT}'] = ${DYNAMIC_IMPORT_REPLACEMENT};`;
           }
         }
         self.importedExternalsSyntax[name] = `import ${
-          defaultSpecifier !== null ? `${defaultSpecifier},` : ''
+          defaultSpecifier !== null
+            ? `${defaultSpecifier}${specificSpecifiers.length > 0 ? ',' : ''}`
+            : ''
         }${
           specificSpecifiers.length > 0 ? `{${specificSpecifiers.join(',')}}` : ''
         } from '${name}';`;

--- a/test/export-named/fixtures/multiple.esm.advanced.js
+++ b/test/export-named/fixtures/multiple.esm.advanced.js
@@ -1,1 +1,1 @@
-function bar(){console.log(1)};function baz(a){console.log(a)};var foo=1;export{bar,baz,foo};
+class b{constructor(a){this.a=a}console(){console.log(this.a)}}function bar(){console.log(1)};function baz(a){console.log(a)};var foo=1;export{b as ExportedClass,bar,baz,foo};

--- a/test/export-named/fixtures/multiple.esm.default.js
+++ b/test/export-named/fixtures/multiple.esm.default.js
@@ -1,1 +1,1 @@
-function bar(){console.log(1)};function baz(a){console.log(a)};var foo=1;export{bar,baz,foo};
+class b{constructor(a){this.name_=a}console(){console.log(this.name_)}}function bar(){console.log(1)};function baz(a){console.log(a)};var foo=1;export{b as ExportedClass,bar,baz,foo};

--- a/test/export-named/fixtures/multiple.esm.es5.js
+++ b/test/export-named/fixtures/multiple.esm.es5.js
@@ -1,1 +1,1 @@
-function bar(){console.log(1)};function baz(a){console.log(a)};var foo=1;export{bar,baz,foo};
+function b(a){this.name_=a}b.prototype.console=function(){console.log(this.name_)};function bar(){console.log(1)};function baz(a){console.log(a)};var foo=1;export{b as ExportedClass,bar,baz,foo};

--- a/test/export-named/fixtures/multiple.js
+++ b/test/export-named/fixtures/multiple.js
@@ -5,4 +5,16 @@ const bar = function() {
 const baz = function(name) {
   console.log(name);
 }
-export{foo, bar, baz};
+class ExportedClass {
+  constructor(name) {
+    /**
+     * @private {string}
+     */
+    this.name_ = name;
+  }
+
+  console() {
+    console.log(this.name_);
+  }
+}
+export{foo, bar, baz, ExportedClass};

--- a/test/export-variables/fixtures/class.esm.advanced.js
+++ b/test/export-variables/fixtures/class.esm.advanced.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.a=b}console(){console.log(this.a)}}export var Exported=a;
+class a{constructor(b){this.a=b}console(){console.log(this.a)}}export{a as Exported};

--- a/test/export-variables/fixtures/class.esm.default.js
+++ b/test/export-variables/fixtures/class.esm.default.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}export var Exported=a;
+class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}export{a as Exported};

--- a/test/export-variables/fixtures/class.esm.es5.js
+++ b/test/export-variables/fixtures/class.esm.es5.js
@@ -1,1 +1,1 @@
-function a(b){this.name_=b}a.prototype.console=function(){console.log(this.name_)};export var Exported=a;
+function a(b){this.name_=b}a.prototype.console=function(){console.log(this.name_)};export{a as Exported};

--- a/test/generator.js
+++ b/test/generator.js
@@ -54,7 +54,7 @@ async function compile(category, name, codeSplit, closureFlags, optionKey, forma
   const bundle = await rollup.rollup({
     input: fixtureLocation(category, name, format, optionKey, false),
     plugins: [compiler(closureFlags[optionKey])],
-    external: ['lodash', './external.js', './external-default.js'],
+    external: ['lodash', 'lodash2', 'lodash3', './external.js', './external-default.js'],
     experimentalCodeSplitting: codeSplit,
     onwarn: _ => null,
   });

--- a/test/import/fixtures/external.esm.advanced.js
+++ b/test/import/fixtures/external.esm.advanced.js
@@ -1,1 +1,1 @@
-import _,{foo} from 'lodash';console.log("lodash",_,foo);
+import j from 'lodash3';import {thing,thing2} from 'lodash2';import _,{foo,bar} from 'lodash';console.log("lodash",_,foo,bar,thing,thing2,j);

--- a/test/import/fixtures/external.esm.advanced.js
+++ b/test/import/fixtures/external.esm.advanced.js
@@ -1,1 +1,1 @@
-import _ from 'lodash';console.log("lodash",_);
+import _,{foo} from 'lodash';console.log("lodash",_,foo);

--- a/test/import/fixtures/external.esm.default.js
+++ b/test/import/fixtures/external.esm.default.js
@@ -1,1 +1,1 @@
-import _,{foo} from 'lodash';console.log("lodash",_,foo);
+import j from 'lodash3';import {thing,thing2} from 'lodash2';import _,{foo,bar} from 'lodash';console.log("lodash",_,foo,bar,thing,thing2,j);

--- a/test/import/fixtures/external.esm.default.js
+++ b/test/import/fixtures/external.esm.default.js
@@ -1,1 +1,1 @@
-import _ from 'lodash';console.log("lodash",_);
+import _,{foo} from 'lodash';console.log("lodash",_,foo);

--- a/test/import/fixtures/external.esm.es5.js
+++ b/test/import/fixtures/external.esm.es5.js
@@ -1,1 +1,1 @@
-import _,{foo} from 'lodash';console.log("lodash",_,foo);
+import j from 'lodash3';import {thing,thing2} from 'lodash2';import _,{foo,bar} from 'lodash';console.log("lodash",_,foo,bar,thing,thing2,j);

--- a/test/import/fixtures/external.esm.es5.js
+++ b/test/import/fixtures/external.esm.es5.js
@@ -1,1 +1,1 @@
-import _ from 'lodash';console.log("lodash",_);
+import _,{foo} from 'lodash';console.log("lodash",_,foo);

--- a/test/import/fixtures/external.js
+++ b/test/import/fixtures/external.js
@@ -1,3 +1,5 @@
-import _, { foo } from 'lodash';
+import _, { foo, bar as baz } from 'lodash';
+import {thing, thing2 as thing3} from 'lodash2';
+import j from 'lodash3';
 
-console.log('lodash', _, foo);
+console.log('lodash', _, foo, baz, thing, thing3, j);

--- a/test/import/fixtures/external.js
+++ b/test/import/fixtures/external.js
@@ -1,3 +1,3 @@
-import _ from 'lodash';
+import _, { foo } from 'lodash';
 
-console.log('lodash', _);
+console.log('lodash', _, foo);

--- a/test/provided-externs/fixtures/class.esm.advanced.js
+++ b/test/provided-externs/fixtures/class.esm.advanced.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.a=b}console(){console.log(this.a)}}export var ExportThis=a;
+class a{constructor(b){this.a=b}console(){console.log(this.a)}}export{a as ExportThis};

--- a/test/provided-externs/fixtures/class.esm.default.js
+++ b/test/provided-externs/fixtures/class.esm.default.js
@@ -1,1 +1,1 @@
-class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}export var ExportThis=a;
+class a{constructor(b){this.name_=b}console(){console.log(this.name_)}}export{a as ExportThis};

--- a/test/provided-externs/fixtures/class.esm.es5.js
+++ b/test/provided-externs/fixtures/class.esm.es5.js
@@ -1,1 +1,1 @@
-function a(b){this.name_=b}a.prototype.console=function(){console.log(this.name_)};export var ExportThis=a;
+function a(b){this.name_=b}a.prototype.console=function(){console.log(this.name_)};export{a as ExportThis};


### PR DESCRIPTION
When exporting identifiers, we can avoid creating a variable reference to the name we want to export.

Also, we never currently inline export (even for sole export in a module) since we do not restore the name of the original export across the module.