### PR TITLE
Option to remove strict mode declarations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,13 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
     options: options => (inputOptions = options),
     buildStart() {
       context = this;
-      sourceTransforms = createSourceTransforms(context, mangler, inputOptions, {});
+      sourceTransforms = createSourceTransforms(
+        context,
+        requestedCompileOptions,
+        mangler,
+        inputOptions,
+        {},
+      );
       if (
         'compilation_level' in requestedCompileOptions &&
         requestedCompileOptions.compilation_level === 'ADVANCED_OPTIMIZATIONS' &&
@@ -68,6 +74,7 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
 
       const renderChunkTransforms = createChunkTransforms(
         context,
+        requestedCompileOptions,
         mangler,
         inputOptions,
         outputOptions,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -15,7 +15,7 @@
  */
 
 import { logTransformChain } from './debug';
-import { TransformInterface } from './types';
+import { TransformInterface, PluginOptions } from './types';
 import { PluginContext, InputOptions, OutputOptions, TransformSourceDescription } from 'rollup';
 import { Mangle } from './transformers/mangle';
 import * as path from 'path';
@@ -25,6 +25,7 @@ import { createDecodedSourceMap, createExistingRawSourceMap } from './source-map
 
 class Transform implements TransformInterface {
   protected context: PluginContext;
+  protected pluginOptions: PluginOptions;
   protected mangler: Mangle;
   protected inputOptions: InputOptions;
   protected outputOptions: OutputOptions;
@@ -32,11 +33,13 @@ class Transform implements TransformInterface {
 
   constructor(
     context: PluginContext,
+    pluginOptions: PluginOptions,
     mangler: Mangle,
     inputOptions: InputOptions,
     outputOptions: OutputOptions,
   ) {
     this.context = context;
+    this.pluginOptions = pluginOptions;
     this.mangler = mangler;
     this.inputOptions = inputOptions;
     this.outputOptions = outputOptions;

--- a/src/transformers/chunk/transforms.ts
+++ b/src/transformers/chunk/transforms.ts
@@ -30,6 +30,8 @@ import StrictTransform from './strict';
 import ConstTransform from './const';
 import { ChunkTransform, chunkLifecycle } from '../../transform';
 import { Mangle } from '../mangle';
+import { CompileOptions } from 'google-closure-compiler';
+import { pluckPluginOptions } from '../../options';
 
 const TRANSFORMS: Array<typeof ChunkTransform> = [
   ConstTransform,
@@ -44,17 +46,24 @@ const TRANSFORMS: Array<typeof ChunkTransform> = [
 /**
  * Instantiate transform class instances for the plugin invocation.
  * @param context Plugin context to bind for each transform instance.
+ * @param requestedCompileOptions Originally requested compile options from configuration.
+ * @param mangler Mangle instance used for this transform instance.
  * @param inputOptions Rollup input options
  * @param outputOptions Rollup output options
  * @return Instantiated transform class instances for the given entry point.
  */
-export const create = (
+export function create(
   context: PluginContext,
+  requestedCompileOptions: CompileOptions,
   mangler: Mangle,
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
-): Array<ChunkTransform> =>
-  TRANSFORMS.map(transform => new transform(context, mangler, inputOptions, outputOptions));
+): Array<ChunkTransform> {
+  const pluginOptions = pluckPluginOptions(requestedCompileOptions);
+  return TRANSFORMS.map(
+    transform => new transform(context, pluginOptions, mangler, inputOptions, outputOptions),
+  );
+}
 
 /**
  * Run each transform's `preCompilation` phase.

--- a/src/transformers/source/transforms.ts
+++ b/src/transformers/source/transforms.ts
@@ -19,6 +19,7 @@ import { SourceTransform, sourceLifecycle } from '../../transform';
 // import { ExportTransform } from './exports';
 import { Mangle } from '../mangle';
 import { PluginContext, InputOptions, OutputOptions, TransformSourceDescription } from 'rollup';
+import { CompileOptions } from 'google-closure-compiler';
 
 const TRANSFORMS: Array<typeof SourceTransform> = [];
 // Temporarily disabling SourceTransforms, aligning for future release.
@@ -27,17 +28,20 @@ const TRANSFORMS: Array<typeof SourceTransform> = [];
 /**
  * Instantiate transform class instances for the plugin invocation.
  * @param context Plugin context to bind for each transform instance.
+ * @param requestedCompileOptions Originally requested compile options from configuration.
+ * @param mangler Mangle instance used for this transform instance.
  * @param inputOptions Rollup input options
  * @param outputOptions Rollup output options
  * @return Instantiated transform class instances for the given entry point.
  */
 export const create = (
   context: PluginContext,
+  requestedCompileOptions: CompileOptions,
   mangler: Mangle,
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
 ): Array<SourceTransform> =>
-  TRANSFORMS.map(transform => new transform(context, mangler, inputOptions, outputOptions));
+  TRANSFORMS.map(transform => new transform(context, {}, mangler, inputOptions, outputOptions));
 
 /**
  * Run each transform's `transform` lifecycle.

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,3 +62,7 @@ export type TransformMethod = (code: string) => Promise<MagicString>;
 export interface TransformInterface {
   name: string;
 }
+
+export interface PluginOptions {
+  [key: string]: string | boolean;
+}

--- a/test/strict-removal/fixtures/option.iife.default.js
+++ b/test/strict-removal/fixtures/option.iife.default.js
@@ -1,0 +1,1 @@
+(function(a){a.thing=1;return a})({});

--- a/test/strict-removal/fixtures/option.js
+++ b/test/strict-removal/fixtures/option.js
@@ -1,0 +1,3 @@
+'use strict';
+
+export const thing = 1;

--- a/test/strict-removal/option.test.js
+++ b/test/strict-removal/option.test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  generator,
+  DEFAULT_CLOSURE_OPTIONS,
+  PRETTY_PRINT_CLOSURE_OPTIONS,
+  ADVANCED_CLOSURE_OPTIONS,
+  ES5_STRICT_CLOSURE_OPTIONS,
+} from '../generator';
+
+const closureOptions = {
+  default: Object.assign({}, DEFAULT_CLOSURE_OPTIONS.default, {
+    remove_strict_directive: true,
+  }),
+};
+
+generator('strict-removal', 'option', undefined, ['iife'], closureOptions);


### PR DESCRIPTION
This change allows users to remove strict mode declarations with an option, similar to the already present check for when an output is a module.

Option name: `remove_strict_directive`