### PR TITLE
Remove and Restore Hashbangs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,12 @@ import {
 } from './transformers/source/transforms';
 import { preCompilation, create as createChunkTransforms } from './transformers/chunk/transforms';
 import { Mangle } from './transformers/mangle';
+import { Ebbinghaus } from './transformers/ebbinghaus';
 import { SourceTransform } from './transform';
 
 export default function closureCompiler(requestedCompileOptions: CompileOptions = {}): Plugin {
   const mangler: Mangle = new Mangle();
+  const memory: Ebbinghaus = new Ebbinghaus();
   let inputOptions: InputOptions;
   let context: PluginContext;
   let sourceTransforms: Array<SourceTransform>;
@@ -49,6 +51,7 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
         context,
         requestedCompileOptions,
         mangler,
+        memory,
         inputOptions,
         {},
       );
@@ -76,6 +79,7 @@ export default function closureCompiler(requestedCompileOptions: CompileOptions 
         context,
         requestedCompileOptions,
         mangler,
+        memory,
         inputOptions,
         outputOptions,
       );

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -18,6 +18,7 @@ import { logTransformChain } from './debug';
 import { TransformInterface, PluginOptions } from './types';
 import { PluginContext, InputOptions, OutputOptions, TransformSourceDescription } from 'rollup';
 import { Mangle } from './transformers/mangle';
+import { Ebbinghaus } from './transformers/ebbinghaus';
 import * as path from 'path';
 import MagicString from 'magic-string';
 import { DecodedSourceMap as RemappingDecodedSourceMap } from '@ampproject/remapping/dist/types/types';

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -27,6 +27,7 @@ class Transform implements TransformInterface {
   protected context: PluginContext;
   protected pluginOptions: PluginOptions;
   protected mangler: Mangle;
+  protected memory: Ebbinghaus;
   protected inputOptions: InputOptions;
   protected outputOptions: OutputOptions;
   public name: string = 'Transform';
@@ -35,12 +36,14 @@ class Transform implements TransformInterface {
     context: PluginContext,
     pluginOptions: PluginOptions,
     mangler: Mangle,
+    memory: Ebbinghaus,
     inputOptions: InputOptions,
     outputOptions: OutputOptions,
   ) {
     this.context = context;
     this.pluginOptions = pluginOptions;
     this.mangler = mangler;
+    this.memory = memory;
     this.inputOptions = inputOptions;
     this.outputOptions = outputOptions;
   }

--- a/src/transformers/chunk/hashbang-apply.ts
+++ b/src/transformers/chunk/hashbang-apply.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChunkTransform } from '../../transform';
+import { TransformInterface } from '../../types';
+import MagicString from 'magic-string';
+
+/**
+ * Closure Compiler will not compile code that is prefixed with a hashbang (common to rollup output for CLIs).
+ *
+ * This transform will restore the hashbang if Ebbinghaus knows it exists.
+ */
+export default class HashbangApplyTransform extends ChunkTransform implements TransformInterface {
+  public name = 'HashbangApplyTransform';
+
+  /**
+   * @param source MagicString of source to process post Closure Compilation.
+   */
+  public async post(source: MagicString): Promise<MagicString> {
+    if (this.memory.hashbang === null) {
+      return source;
+    }
+
+    source.prepend(this.memory.hashbang + '\n');
+    return source;
+  }
+}

--- a/src/transformers/chunk/hashbang-remove.ts
+++ b/src/transformers/chunk/hashbang-remove.ts
@@ -21,20 +21,24 @@ import MagicString from 'magic-string';
 /**
  * Closure Compiler will not compile code that is prefixed with a hashbang (common to rollup output for CLIs).
  *
- * This transform will restore the hashbang if Ebbinghaus knows it exists.
+ * This transform will remove the hashbang (if present) and ask Ebbinghaus to remember if for after compilation.
  */
-export default class HashbangTransform extends ChunkTransform implements TransformInterface {
-  public name = 'HashbangTransform';
+export default class HashbangRemoveTransform extends ChunkTransform implements TransformInterface {
+  public name = 'HashbangRemoveTransform';
 
   /**
    * @param source MagicString of source to process post Closure Compilation.
    */
-  public async post(source: MagicString): Promise<MagicString> {
-    if (this.memory.hashbang === null) {
+  public async pre(source: MagicString): Promise<MagicString> {
+    const stringified = source.trim().toString();
+    const match = /^#!.*/.exec(stringified);
+
+    if (!match) {
       return source;
     }
 
-    source.prepend(this.memory.hashbang + '\n');
+    this.memory.hashbang = match[0];
+    source.remove(0, match[0].length);
     return source;
   }
 }

--- a/src/transformers/chunk/hashbang.ts
+++ b/src/transformers/chunk/hashbang.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChunkTransform } from '../../transform';
+import { TransformInterface } from '../../types';
+import MagicString from 'magic-string';
+
+/**
+ * Closure Compiler will not compile code that is prefixed with a hashbang (common to rollup output for CLIs).
+ *
+ * This transform will restore the hashbang if Ebbinghaus knows it exists.
+ */
+export default class HashbangTransform extends ChunkTransform implements TransformInterface {
+  public name = 'HashbangTransform';
+
+  /**
+   * @param source MagicString of source to process post Closure Compilation.
+   */
+  public async post(source: MagicString): Promise<MagicString> {
+    if (this.memory.hashbang === null) {
+      return source;
+    }
+
+    source.prepend(this.memory.hashbang + '\n');
+    return source;
+  }
+}

--- a/src/transformers/chunk/transforms.ts
+++ b/src/transformers/chunk/transforms.ts
@@ -21,7 +21,8 @@ import {
   RenderedChunk,
   TransformSourceDescription,
 } from 'rollup';
-import HashbangTransform from './hashbang';
+import HashbangRemoveTransform from './hashbang-remove';
+import HashbangApplyTransform from './hashbang-apply';
 import IifeTransform from './iife';
 import CJSTransform from './cjs';
 import LiteralComputedKeys from './literal-computed-keys';
@@ -36,6 +37,8 @@ import { CompileOptions } from 'google-closure-compiler';
 import { pluckPluginOptions } from '../../options';
 
 const TRANSFORMS: Array<typeof ChunkTransform> = [
+  HashbangRemoveTransform,
+  // Acorn can parse content starting here
   ConstTransform,
   IifeTransform,
   CJSTransform,
@@ -43,9 +46,8 @@ const TRANSFORMS: Array<typeof ChunkTransform> = [
   StrictTransform,
   ExportTransform,
   ImportTransform,
-  // After this point Transforms cannot use Acorn to parse source.
-  // Hashbangs are added back, which makes the content unparseable.
-  HashbangTransform,
+  // Acorn cannot parse content starting here.
+  HashbangApplyTransform,
 ];
 
 /**

--- a/src/transformers/ebbinghaus.ts
+++ b/src/transformers/ebbinghaus.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Hermann Ebbinghaus is credited with discovering the forgetting curve.
+ *
+ * This class stores data the compiler would typically loose to the forgetting curve.
+ * For instance:
+ *  - original source contained a `hashbang`
+ *  - original source used external imports
+ *
+ * This data can be used later to inform transforms following Closure Compiler.
+ *
+ * For more information, visit: https://en.wikipedia.org/wiki/Hermann_Ebbinghaus
+ */
+
+export class Ebbinghaus {
+  public hashbang: string | null = null;
+}

--- a/src/transformers/source/hashbang.ts
+++ b/src/transformers/source/hashbang.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SourceTransform } from '../../transform';
+import { TransformInterface } from '../../types';
+import MagicString from 'magic-string';
+
+/**
+ * Closure Compiler will not compile code that is prefixed with a hashbang (common to rollup output for CLIs).
+ *
+ * This transform will remove the hashbang (if present) and ask Ebbinghaus to remember if for after compilation.
+ */
+export default class HashbangTransform extends SourceTransform implements TransformInterface {
+  public name = 'HashbangTransform';
+
+  public transform = async (id: string, source: MagicString): Promise<MagicString> => {
+    const stringified = source.trim().toString();
+    const match = /^#!.*/.exec(stringified);
+
+    if (!match) {
+      return source;
+    }
+
+    this.memory.hashbang = match[0];
+    source.remove(0, match[0].length);
+    return source;
+  };
+}

--- a/src/transformers/source/transforms.ts
+++ b/src/transformers/source/transforms.ts
@@ -15,14 +15,14 @@
  */
 
 import { SourceTransform, sourceLifecycle } from '../../transform';
-// import { ImportTransform } from './imports';
-// import { ExportTransform } from './exports';
 import { Mangle } from '../mangle';
 import { PluginContext, InputOptions, OutputOptions, TransformSourceDescription } from 'rollup';
 import { CompileOptions } from 'google-closure-compiler';
+import HashbangTransform from './hashbang';
+import { Ebbinghaus } from '../ebbinghaus';
 
-const TRANSFORMS: Array<typeof SourceTransform> = [];
-// Temporarily disabling SourceTransforms, aligning for future release.
+const TRANSFORMS: Array<typeof SourceTransform> = [HashbangTransform];
+// Temporarily disabling many SourceTransforms, aligning for future release.
 // ImportTransform, ExportTransform
 
 /**
@@ -30,6 +30,7 @@ const TRANSFORMS: Array<typeof SourceTransform> = [];
  * @param context Plugin context to bind for each transform instance.
  * @param requestedCompileOptions Originally requested compile options from configuration.
  * @param mangler Mangle instance used for this transform instance.
+ * @param memory Ebbinghaus instance used to store information that could be lost from source.
  * @param inputOptions Rollup input options
  * @param outputOptions Rollup output options
  * @return Instantiated transform class instances for the given entry point.
@@ -38,10 +39,13 @@ export const create = (
   context: PluginContext,
   requestedCompileOptions: CompileOptions,
   mangler: Mangle,
+  memory: Ebbinghaus,
   inputOptions: InputOptions,
   outputOptions: OutputOptions,
 ): Array<SourceTransform> =>
-  TRANSFORMS.map(transform => new transform(context, {}, mangler, inputOptions, outputOptions));
+  TRANSFORMS.map(
+    transform => new transform(context, {}, mangler, memory, inputOptions, outputOptions),
+  );
 
 /**
  * Run each transform's `transform` lifecycle.

--- a/test/generator.js
+++ b/test/generator.js
@@ -56,7 +56,7 @@ const fixtureLocation = (category, name, format, optionsKey, minified = false) =
       : `${name}.js`
   }`;
 
-async function compile(category, name, codeSplit, closureFlags, optionKey, format, wrapper) {
+async function compile(category, name, codeSplit, closureFlags, optionKey, format, wrapper, banner) {
   const bundle = await rollup.rollup({
     input: fixtureLocation(category, name, format, optionKey, false),
     plugins: [compiler(closureFlags[optionKey])],
@@ -69,6 +69,7 @@ async function compile(category, name, codeSplit, closureFlags, optionKey, forma
     format,
     name: wrapper,
     sourcemap: true,
+    banner,
   });
 
   const output = [];
@@ -107,7 +108,7 @@ async function compile(category, name, codeSplit, closureFlags, optionKey, forma
   return output;
 }
 
-function generate(shouldFail, category, name, codeSplit, formats, closureFlags, wrapper) {
+function generate(shouldFail, category, name, codeSplit, formats, closureFlags, wrapper, banner) {
   const targetLength = longest(formats);
   const optionLength = longest(Object.keys(closureFlags));
 
@@ -125,6 +126,7 @@ function generate(shouldFail, category, name, codeSplit, formats, closureFlags, 
             optionKey,
             format,
             wrapper,
+            banner,
           );
 
           t.plan(output.length);
@@ -144,8 +146,9 @@ function failureGenerator(
   formats = [ESM_OUTPUT],
   closureFlags = defaultClosureFlags,
   wrapper = null,
+  banner = null,
 ) {
-  generate(true, category, name, codeSplit, formats, closureFlags, wrapper);
+  generate(true, category, name, codeSplit, formats, closureFlags, wrapper, banner);
 }
 
 function generator(
@@ -155,8 +158,9 @@ function generator(
   formats = [ESM_OUTPUT],
   closureFlags = defaultClosureFlags,
   wrapper = null,
+  banner = null,
 ) {
-  generate(false, category, name, codeSplit, formats, closureFlags, wrapper);
+  generate(false, category, name, codeSplit, formats, closureFlags, wrapper, banner);
 }
 
 module.exports = {

--- a/test/hashbang/fixtures/hashbang-banner.esm.advanced.js
+++ b/test/hashbang/fixtures/hashbang-banner.esm.advanced.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export function foo(){return"hello world"};

--- a/test/hashbang/fixtures/hashbang-banner.esm.default.js
+++ b/test/hashbang/fixtures/hashbang-banner.esm.default.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export function foo(){return"hello world"};

--- a/test/hashbang/fixtures/hashbang-banner.esm.es5.js
+++ b/test/hashbang/fixtures/hashbang-banner.esm.es5.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export function foo(){return"hello world"};

--- a/test/hashbang/fixtures/hashbang-banner.esm.pretty.js
+++ b/test/hashbang/fixtures/hashbang-banner.esm.pretty.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+export function foo(){
+  return "hello world";
+};

--- a/test/hashbang/fixtures/hashbang-banner.js
+++ b/test/hashbang/fixtures/hashbang-banner.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'hello world';
+}

--- a/test/hashbang/fixtures/hashbang-preserved.esm.advanced.js
+++ b/test/hashbang/fixtures/hashbang-preserved.esm.advanced.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export function foo(){return"hello world"};

--- a/test/hashbang/fixtures/hashbang-preserved.esm.default.js
+++ b/test/hashbang/fixtures/hashbang-preserved.esm.default.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export function foo(){return"hello world"};

--- a/test/hashbang/fixtures/hashbang-preserved.esm.es5.js
+++ b/test/hashbang/fixtures/hashbang-preserved.esm.es5.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export function foo(){return"hello world"};

--- a/test/hashbang/fixtures/hashbang-preserved.esm.pretty.js
+++ b/test/hashbang/fixtures/hashbang-preserved.esm.pretty.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+export function foo(){
+  return "hello world";
+};

--- a/test/hashbang/fixtures/hashbang-preserved.js
+++ b/test/hashbang/fixtures/hashbang-preserved.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+export function foo() {
+	return 'hello world';
+}

--- a/test/hashbang/hashbang-banner.test.js
+++ b/test/hashbang/hashbang-banner.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generator } from '../generator';
+
+generator(
+  'hashbang',
+  'hashbang-banner',
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  '#!/usr/bin/env node',
+);

--- a/test/hashbang/hashbang-preserved.test.js
+++ b/test/hashbang/hashbang-preserved.test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generator } from '../generator';
+
+generator('hashbang', 'hashbang-preserved');


### PR DESCRIPTION
Hashbangs are not valid output for source code, so this change removes them during processing of source and stores them in a new memory object used across all transforms.

Named after Hermann Ebbinghaus, this memory object is intended to be used for things learned from source but forgotten outside the scope of their discovery (similar to the forgetting curve).