### PR TITLE
Fix SyntaxError when computed keys have invalid javascript identifier

### DIFF
--- a/src/transformers/chunk/literal-computed-keys.ts
+++ b/src/transformers/chunk/literal-computed-keys.ts
@@ -43,11 +43,11 @@ export default class LiteralComputedKeys extends ChunkTransform implements Trans
           if (isProperty(property) && property.computed && property.key.type === 'Literal') {
             const [propertyStart]: Range = property.range as Range;
             const [valueStart]: Range = property.value.range as Range;
-
+            const keyValue = property.key.raw ?? property.key.value;
             source.overwrite(
               propertyStart,
               valueStart,
-              `${property.key.value}${property.value.type !== 'FunctionExpression' ? ':' : ''}`,
+              `${keyValue}${property.value.type !== 'FunctionExpression' ? ':' : ''}`,
             );
           }
         }

--- a/test/literal-computed-keys/fixtures/mixed-keys.esm.advanced.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.esm.advanced.js
@@ -1,1 +1,1 @@
-console.log({0:"value",1:"value",2:"value2",3:"value3",4(a){console.log(a)},5(a){console.log(a)}})
+console.log({0:"value",1:"value",2:"value2",3:"value3",4(a){console.log(a)},5(a){console.log(a)},"6#":"value6"})

--- a/test/literal-computed-keys/fixtures/mixed-keys.esm.default.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.esm.default.js
@@ -1,1 +1,1 @@
-console.log({0:"value",1:"value",2:"value2",3:"value3",4(a){console.log(a)},5(a){console.log(a)}})
+console.log({0:"value",1:"value",2:"value2",3:"value3",4(a){console.log(a)},5(a){console.log(a)},"6#":"value6"})

--- a/test/literal-computed-keys/fixtures/mixed-keys.esm.es5.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.esm.es5.js
@@ -1,1 +1,1 @@
-var a={};console.log((a["0"]="value",a[1]="value",a[2]="value2",a[3]="value3",a[4]=function(b){console.log(b)},a[5]=function(b){console.log(b)},a))
+var a={};console.log((a["0"]="value",a[1]="value",a[2]="value2",a[3]="value3",a[4]=function(b){console.log(b)},a[5]=function(b){console.log(b)},a["6#"]="value6",a))

--- a/test/literal-computed-keys/fixtures/mixed-keys.esm.pretty.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.esm.pretty.js
@@ -3,4 +3,4 @@ console.log({0:"value", 1:"value", 2:"value2", 3:"value3", 4(a) {
   console.log(a);
 }, 5(a) {
   console.log(a);
-}})
+}, "6#":"value6"})

--- a/test/literal-computed-keys/fixtures/mixed-keys.js
+++ b/test/literal-computed-keys/fixtures/mixed-keys.js
@@ -12,5 +12,6 @@ console.log({
   },
   5(value) {
     console.log(bar(value));
-  }
+  },
+  ['6#']: 'value6'
 });


### PR DESCRIPTION
When Computed property names contain invalid javascript identifiers, like '#', '!',
acron parser fails because of forgetting to preserve quotation marks.
close #465