### PR TITLE
Fix export async function failure: 'SyntaxError: Cannot use keyword 'await' outside an async function'

### DIFF
--- a/test/export-default/async-function.test.js
+++ b/test/export-default/async-function.test.js
@@ -1,0 +1,3 @@
+import { generator } from '../generator';
+
+generator('export-default', 'async-function', false, ['esm'], { stable: {} });

--- a/test/export-default/fixtures/async-function.esm.stable.js
+++ b/test/export-default/fixtures/async-function.esm.stable.js
@@ -1,0 +1,1 @@
+async function asyncTest(){await Promise.resolve("async-test");console.log("async-test")};async function asyncTestWithArgument(a){await Promise.resolve("async-test-with-argument");console.log(a)};export{asyncTest,asyncTestWithArgument}

--- a/test/export-default/fixtures/async-function.js
+++ b/test/export-default/fixtures/async-function.js
@@ -1,0 +1,9 @@
+export async function asyncTest() {
+    await Promise.resolve('async-test');
+    console.log('async-test')
+}
+
+export async function asyncTestWithArgument(argument) {
+    await Promise.resolve('async-test-with-argument');
+    console.log(argument)
+}


### PR DESCRIPTION
Fix issue #466 